### PR TITLE
Check if default primary key :integer type is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ gem 'strong_migrations'
 
 ## Dangerous Operations
 
+- create a table with default primary key type (integer: 4 bytes)
 - adding a column with a non-null default value to an existing table
 - changing the type of a column
 - renaming a table
@@ -34,6 +35,18 @@ Also checks for best practices:
 - keeping indexes to three columns or less
 
 ## The Zero Downtime Way
+
+### Create a table with default primary key type (integer: 4 bytes)
+
+create_table is creating a primary key of integer (4 bytes) by default.
+You might run out of id's if you insert a lot of data. Max value is 2,147,483,647.
+You might want to use bigint (8 bytes) type instead. Max value is 9,223,372,036,854,775,807.
+
+```ruby
+create_table :example, id: false do |t|
+  t.integer :id, limit: 8, primary_key: true # bigint (8 bytes)
+end
+```
 
 ### Adding a column with a default value
 

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -1,5 +1,19 @@
 require_relative "test_helper"
 
+class CreateTablePrimaryKeyTypeSafe < ActiveRecord::Migration
+  def change
+    create_table :example, id: false, force: :cascade do |t|
+      t.integer :id, limit: 8, primary_key: true # bigint (8 bytes)
+    end
+  end
+end
+
+class CreateTablePrimaryKeyTypeUnsafe < ActiveRecord::Migration
+  def change
+    create_table :table, force: :cascade
+  end
+end
+
 class AddIndex < ActiveRecord::Migration
   def change
     add_index :users, :name
@@ -86,6 +100,14 @@ class AddIndexColumns < ActiveRecord::Migration
 end
 
 class StrongMigrationsTest < Minitest::Test
+  def test_create_table_primary_key_type_safe
+    assert_safe CreateTablePrimaryKeyTypeSafe
+  end
+
+  def test_create_table_primary_key_type_unsafe
+    assert_unsafe CreateTablePrimaryKeyTypeUnsafe
+  end
+
   def test_add_index
     skip unless postgres?
     assert_unsafe AddIndex

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,8 @@ end
 
 class CreateUsers < ActiveRecord::Migration
   def change
-    create_table "users", force: :cascade do |t|
+    create_table "users", id: false, force: :cascade do |t|
+      t.integer :id, limit: 8, primary_key: true
       t.string :name
     end
   end


### PR DESCRIPTION
### Check if default primary key :integer type is used

- To address https://github.com/ankane/strong_migrations/issues/4

**Notes**:
 
- Might not be enough to just check if `:id` flag is false but should cover most of cases... We should check in the block, all column with `primary_key: true` flag and the `:limit` value.