### PR TITLE
Leverage Rails 5 ignored_columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,13 @@ If you really have to:
 Tell ActiveRecord to ignore the column from its cache.
 
 ```ruby
-class User
+# For Rails 5+
+class User < ActiveRecord::Base
+  self.ignored_columns = %w(some_column)
+end
+
+# For Rails < 5
+class User < ActiveRecord::Base
   def self.columns
     super.reject { |c| c.name == "some_column" }
   end


### PR DESCRIPTION
Update the "Removing a column" section to include details on the `ActiveRecord::Base.ignored_columns` method that landed in https://github.com/rails/rails/pull/21720.