### PR TITLE
Add #in_batches code example for Rails 5+ batch processing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ class AddSomeColumnToUsers < ActiveRecord::Migration
     # 2
     commit_db_transaction
 
-    # 3
+    # 3.a (Rails 5+)
+    User.in_batches.update_all some_column: "default_value"
+                                                             
+    # 3.b (Rails < 5)
     User.find_in_batches do |users|
       User.where(id: users.map(&:id)).update_all some_column: "default_value"
     end


### PR DESCRIPTION
PR for https://github.com/ankane/strong_migrations/issues/14 .

[#in_batches](http://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-in_batches) makes batch makes batch processing a bit cleaner.

Honestly not sure its worth cluttering up the snippet to add this, and since the method was only added in rails 5 I don't think it should replace the previous example.

Feel free to reject this PR. I'm pretty enthusiastic about #in_batches but that seems tangential to the concern of safe migrations.