### PR TITLE
Mark remove index operation as dangerous

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,5 @@ matrix:
     - gemfile: test/gemfiles/mysql2.gemfile
       env: ADAPTER=mysql2
       rvm: 2.4.1
+addons:
+  postgresql: "9.2"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ gem 'strong_migrations'
 - renaming a column
 - removing a column
 - executing arbitrary SQL
-- adding an index non-concurrently (Postgres only)
+- adding/removing an index non-concurrently (Postgres only)
 - adding a `json` column to an existing table (Postgres only)
 
 For more info, check out:
@@ -112,7 +112,7 @@ end
 
 Once it’s deployed, create a migration to remove the column.
 
-### Adding an index (Postgres)
+### Adding/Removing an index (Postgres)
 
 Add indexes concurrently.
 
@@ -124,6 +124,16 @@ class AddSomeIndexToUsers < ActiveRecord::Migration
   end
 end
 ```
+
+Remove indexed concurrently.
+
+```ruby
+class RemoveSomeIndexToUsers < ActiveRecord::Migration
+  def change
+    commit_db_transaction
+    remove_index :users, column: :some_column, algorithm: :concurrently
+  end
+end
 
 ### Adding a json column (Postgres)
 

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -35,6 +35,13 @@ module StrongMigrations
           if postgresql? && options[:algorithm] != :concurrently && !@new_tables.to_a.include?(args[0].to_s)
             raise_error :add_index
           end
+        when :remove_index
+          if postgresql?
+            options = args[1]
+            if !options.is_a?(Hash) || options[:algorithm] != :concurrently
+              raise_error :remove_index
+            end
+          end
         when :add_column
           type = args[2]
           options = args[3] || {}
@@ -157,6 +164,13 @@ Once it's deployed, wrap this step in a safety_assured { ... } block."
 "Adding an index with more than three columns only helps on extremely large tables.
 
 If you're sure this is what you want, wrap it in a safety_assured { ... } block."
+        when :remove_index
+"Removing a non-concurrent index locks the table. Instead, use:
+
+def change
+  commit_db_transaction
+  remove_index :users, column: :some_column, algorithm: :concurrently
+end"
         when :change_table
 "The strong_migrations gem does not support inspecting what happens inside a
 change_table block, so cannot help you here. Please make really sure that what

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -40,6 +40,36 @@ class AddIndexSchema < TestSchema
   end
 end
 
+class RemoveIndex < TestMigration
+  def change
+    safety_assured { add_index :users, :name, name: "remove_boom" }
+    remove_index :users, name: :remove_boom
+  end
+end
+
+class RemoveIndexUp < TestMigration
+  def self.up
+    safety_assured { add_index :users, :name, name: "remove_boom2" }
+    remove_index :users, name: :remove_boom2
+  end
+end
+
+class RemoveIndexSafePostgres < TestMigration
+  def change
+    safety_assured { add_index :users, :name, name: "remove_boom3" }
+    remove_index :users, name: :remove_boom3, algorithm: :concurrently
+  end
+end
+
+class RemoveIndexSafetyAssured < TestMigration
+  def change
+    safety_assured do
+      add_index :users, :name, name: "remove_boom4"
+      remove_index :users, name: :remove_boom4
+    end
+  end
+end
+
 class AddColumnDefault < TestMigration
   def change
     add_column :users, :nice, :boolean, default: true
@@ -173,6 +203,25 @@ class StrongMigrationsTest < Minitest::Test
   def test_add_index_safe_postgres
     skip unless postgres?
     assert_safe AddIndexSafePostgres
+  end
+
+  def test_remove_index
+    skip unless postgres?
+    assert_unsafe RemoveIndex
+  end
+
+  def test_remove_index_up
+    skip unless postgres?
+    assert_unsafe RemoveIndexUp
+  end
+
+  def test_remove_index_safety_assured
+    assert_safe RemoveIndexSafetyAssured
+  end
+
+  def test_remove_index_safe
+    skip unless postgres?
+    assert_safe RemoveIndexSafePostgres
   end
 
   def test_add_column_default


### PR DESCRIPTION
Since removing index in Postgresql requires an exclusive lock on table. This operation can block migration and cause downtime on a highly usage table.