### PR TITLE
Allow for custom error messages

### DIFF
--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -6,10 +6,24 @@ require "strong_migrations/railtie" if defined?(Rails)
 
 module StrongMigrations
   class << self
-    attr_accessor :auto_analyze, :start_after
+    attr_accessor :auto_analyze, :start_after, :error_messages
   end
   self.auto_analyze = false
   self.start_after = 0
+  self.error_messages = {
+    remove_column:      StrongMigrations::UnsafeMigration::Messages::RemoveColumn,
+    change_table:       StrongMigrations::UnsafeMigration::Messages::ChangeTable,
+    rename_table:       StrongMigrations::UnsafeMigration::Messages::RenameTable,
+    rename_column:      StrongMigrations::UnsafeMigration::Messages::RenameColumn,
+    add_index_columns:  StrongMigrations::UnsafeMigration::Messages::AddIndexColumns,
+    add_index:          StrongMigrations::UnsafeMigration::Messages::AddIndex,
+    add_column_default: StrongMigrations::UnsafeMigration::Messages::AddColumnDefault,
+    add_column_json:    StrongMigrations::UnsafeMigration::Messages::AddColumnJson,
+    change_column:      StrongMigrations::UnsafeMigration::Messages::ChangeColumn,
+    create_table:       StrongMigrations::UnsafeMigration::Messages::CreateTable,
+    add_reference:      StrongMigrations::UnsafeMigration::Messages::AddReference,
+    execute:            StrongMigrations::UnsafeMigration::Messages::Execute
+  }
 end
 
 ActiveRecord::Migration.send(:prepend, StrongMigrations::Migration)

--- a/lib/strong_migrations/unsafe_migration.rb
+++ b/lib/strong_migrations/unsafe_migration.rb
@@ -1,4 +1,105 @@
 module StrongMigrations
   class UnsafeMigration < StandardError
+    class Messages
+      AddColumnDefault = <<~MSG
+        Adding a column with a non-null default requires
+        the entire table and indexes to be rewritten. Instead:
+
+        1. Add the column without a default value
+        2. Add the default value
+        3. Commit the transaction
+        4. Backfill the column
+      MSG
+      AddColumnJson = <<~MSG
+        There's no equality operator for the json column type.
+        Replace all calls to uniq with a custom scope.
+
+          scope :uniq_on_id, -> { select(\"DISTINCT ON (your_table.id) your_table.*\") }
+
+        Once it's deployed, wrap this step in a safety_assured { ... } block.
+      MSG
+      ChangeColumn = <<~MSG
+        Changing the type of an existing column requires
+        the entire table and indexes to be rewritten.
+
+        If you really have to:
+
+        1. Create a new column
+        2. Write to both columns
+        3. Backfill data from the old column to the new column
+        4. Move reads from the old column to the new column
+        5. Stop writing to the old column
+        6. Drop the old column
+      MSG
+      RemoveColumn = <<~MSG
+        ActiveRecord caches attributes which causes problems
+        when removing columns. Be sure to ignored the column:
+
+        class User
+          def self.columns
+            super.reject { |c| c.name == \"some_column\" }
+          end
+        end
+
+        Once it's deployed, wrap this step in a safety_assured { ... } block.
+      MSG
+      RenameColumn = <<~MSG
+        If you really have to:
+
+        1. Create a new column
+        2. Write to both columns
+        3. Backfill data from the old column to new column
+        4. Move reads from the old column to the new column
+        5. Stop writing to the old column
+        6. Drop the old column
+      MSG
+      RenameTable = <<~MSG
+        If you really have to:
+
+        1. Create a new table
+        2. Write to both tables
+        3. Backfill data from the old table to new table
+        4. Move reads from the old table to the new table
+        5. Stop writing to the old table
+        6. Drop the old table
+      MSG
+      AddReference = <<~MSG
+        Adding a non-concurrent index locks the table. Instead, use:
+
+          def change
+            add_reference :users, :reference, index: false
+            commit_db_transaction
+            add_index :users, :reference_id, algorithm: :concurrently
+          end
+      MSG
+      AddIndex = <<~MSG
+        Adding a non-concurrent index locks the table. Instead, use:
+
+          def change
+            commit_db_transaction
+            add_index :users, :some_column, algorithm: :concurrently
+          end
+      MSG
+      AddIndexColumns = <<~MSG
+        Adding an index with more than three columns only helps on extremely large tables.
+
+        If you're sure this is what you want, wrap it in a safety_assured { ... } block.
+      MSG
+      ChangeTable = <<~MSG
+        The strong_migrations gem does not support inspecting what happens inside a
+        change_table block, so cannot help you here. Please make really sure that what
+        you're doing is safe before proceeding, then wrap it in a safety_assured { ... } block.
+      MSG
+      CreateTable = <<~MSG
+        The force option will destroy existing tables.
+        If this is intended, drop the existing table first.
+        Otherwise, remove the option.
+      MSG
+      Execute = <<~MSG
+        The strong_migrations gem does not support inspecting what happens inside an
+        execute call, so cannot help you here. Please make really sure that what
+        you're doing is safe before proceeding, then wrap it in a safety_assured { ... } block.
+      MSG
+    end
   end
 end

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -150,12 +150,12 @@ end
 class StrongMigrationsTest < Minitest::Test
   def test_add_index
     skip unless postgres?
-    assert_unsafe AddIndex
+    assert_unsafe AddIndex, StrongMigrations::UnsafeMigration::Messages::AddIndex
   end
 
   def test_add_index_up
     skip unless postgres?
-    assert_unsafe AddIndexUp
+    assert_unsafe AddIndexUp, StrongMigrations::UnsafeMigration::Messages::AddIndex
   end
 
   def test_add_index_safety_assured
@@ -176,7 +176,7 @@ class StrongMigrationsTest < Minitest::Test
   end
 
   def test_add_column_default
-    assert_unsafe AddColumnDefault
+    assert_unsafe AddColumnDefault, StrongMigrations::UnsafeMigration::Messages::AddColumnDefault
   end
 
   def test_add_column_default_safe
@@ -184,36 +184,36 @@ class StrongMigrationsTest < Minitest::Test
   end
 
   def test_add_column_json
-    assert_unsafe AddColumnJson
+    assert_unsafe AddColumnJson, StrongMigrations::UnsafeMigration::Messages::AddColumnJson
   end
 
   def test_change_column
-    assert_unsafe ChangeColumn
+    assert_unsafe ChangeColumn, StrongMigrations::UnsafeMigration::Messages::ChangeColumn
   end
 
   def test_execute_arbitrary_sql
-    assert_unsafe ExecuteArbitrarySQL
+    assert_unsafe ExecuteArbitrarySQL, StrongMigrations::UnsafeMigration::Messages::Execute
   end
 
   def test_rename_column
-    assert_unsafe RenameColumn
+    assert_unsafe RenameColumn, StrongMigrations::UnsafeMigration::Messages::RenameColumn
   end
 
   def test_rename_table
-    assert_unsafe RenameTable
+    assert_unsafe RenameTable, StrongMigrations::UnsafeMigration::Messages::RenameTable
   end
 
   def test_remove_column
-    assert_unsafe RemoveColumn
+    assert_unsafe RemoveColumn, StrongMigrations::UnsafeMigration::Messages::RemoveColumn
   end
 
   def test_add_index_columns
-    assert_unsafe AddIndexColumns, /more than three columns/
+    assert_unsafe AddIndexColumns, StrongMigrations::UnsafeMigration::Messages::AddIndexColumns
   end
 
   def test_add_reference
     skip unless postgres?
-    assert_unsafe AddReference
+    assert_unsafe AddReference, StrongMigrations::UnsafeMigration::Messages::AddReference
   end
 
   def test_safe_add_reference
@@ -224,14 +224,14 @@ class StrongMigrationsTest < Minitest::Test
   def test_add_reference_default
     skip unless postgres?
     if ActiveRecord::VERSION::MAJOR >= 5
-      assert_unsafe AddReferenceDefault
+      assert_unsafe AddReferenceDefault, StrongMigrations::UnsafeMigration::Messages::AddReference
     else
       assert_safe AddReferenceDefault
     end
   end
 
   def test_create_table_force
-    assert_unsafe CreateTableForce
+    assert_unsafe CreateTableForce, StrongMigrations::UnsafeMigration::Messages::CreateTable
   end
 
   def test_version_safe
@@ -240,6 +240,16 @@ class StrongMigrationsTest < Minitest::Test
 
   def test_version_unsafe
     assert_unsafe VersionUnsafe
+  end
+
+  def test_custom_error_message_remove_index
+    original_message = StrongMigrations.error_messages[:remove_column]
+
+    custom_message = 'This is a custom error message for remove_column'
+    StrongMigrations.error_messages[:remove_column] = custom_message
+    assert_unsafe RemoveColumn, custom_message
+
+    StrongMigrations.error_messages[:remove_column] = original_message
   end
 
   def test_down


### PR DESCRIPTION
@ankane allows for custom messages to be specified in initializer by overriding hash values. Addresses issue #25 