### PR TITLE
adding a null constraint is unsafe

### DIFF
--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -51,6 +51,9 @@ module StrongMigrations
           if postgresql? && index_value
             raise_error :add_reference
           end
+        when :change_column_null
+          unsafe = args[3].nil? && !args[2]
+          raise_error :change_column_null_without_default if unsafe
         when :execute
           raise_error :execute
         end
@@ -165,6 +168,9 @@ you're doing is safe before proceeding, then wrap it in a safety_assured { ... }
 "The force option will destroy existing tables.
 If this is intended, drop the existing table first.
 Otherwise, remove the option."
+        when :change_column_null_without_default
+"When setting a null constraint on a column, a fourth argument to set
+existing nulls with some other value is recommended otherwise null rows will be invalid"
         when :execute
 "The strong_migrations gem does not support inspecting what happens inside an
 execute call, so cannot help you here. Please make really sure that what

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -52,8 +52,8 @@ module StrongMigrations
             raise_error :add_reference
           end
         when :change_column_null
-          unsafe = args[3].nil? && !args[2]
-          raise_error :change_column_null_without_default if unsafe
+          unsafe = !args[2]
+          raise_error :change_column_null if unsafe
         when :execute
           raise_error :execute
         end
@@ -168,9 +168,9 @@ you're doing is safe before proceeding, then wrap it in a safety_assured { ... }
 "The force option will destroy existing tables.
 If this is intended, drop the existing table first.
 Otherwise, remove the option."
-        when :change_column_null_without_default
-"When setting a null constraint on a column, a fourth argument to set
-existing nulls with some other value is recommended otherwise null rows will be invalid"
+        when :change_column_null
+"Adding a null constraint is not a safe operation. Please make really sure that what
+you're doing is safe before proceeding, then wrap it in a safety_assured { ... } block."
         when :execute
 "The strong_migrations gem does not support inspecting what happens inside an
 execute call, so cannot help you here. Please make really sure that what

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -127,6 +127,13 @@ class CreateTableForce < TestMigration
   end
 end
 
+class ChangeColumnNull < TestMigration
+  def change
+    add_column :users, :nickname, :boolean
+    change_column_null :users, :nickname, false
+  end
+end
+
 class VersionSafe < TestMigration
   def change
     add_column :users, :nice2, :boolean, default: true
@@ -228,6 +235,10 @@ class StrongMigrationsTest < Minitest::Test
     else
       assert_safe AddReferenceDefault
     end
+  end
+
+  def test_change_column_null
+    assert_unsafe ChangeColumnNull
   end
 
   def test_create_table_force


### PR DESCRIPTION
Fix for https://github.com/ankane/strong_migrations/issues/29 https://apidock.com/rails/ActiveRecord/ConnectionAdapters/SchemaStatements/change_column_null