### PR TITLE
Leverage disable_ddl_transaction!

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ Add indexes concurrently.
 
 ```ruby
 class AddSomeIndexToUsers < ActiveRecord::Migration
+  disable_ddl_transaction!
+  
   def change
-    commit_db_transaction
     add_index :users, :some_index, algorithm: :concurrently
   end
 end

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -148,9 +148,9 @@ Once that's deployed, wrap this step in a safety_assured { ... } block."
   end"
         when :add_index
 "Adding a non-concurrent index locks the table. Instead, use:
+  disable_ddl_transaction!
 
   def change
-    commit_db_transaction
     add_index :users, :some_column, algorithm: :concurrently
   end"
         when :add_index_columns


### PR DESCRIPTION
This PR updates the recipe for adding indexes concurrently to leverage [disable_ddl_transaction!](http://api.rubyonrails.org/classes/ActiveRecord/Migration.html#method-c-disable_ddl_transaction-21) which is the Rails recommended way of disabling transactions in migrations. 

Note `disable_ddl_transaction!` was introduced in Rails 4.0 so this code won't work in Rails 3.2 but the `algorithm` option for `add_index` was also introduced in Rails 4.0 in this [commit](https://github.com/rails/rails/commit/e199dc1a570d4f0d9a07628268835bce5aab2732) so the recipe was already incorrect for Rails 3.2. Perhaps it's time to drop support Rails 3.2?