### PR TITLE
Add warning for remove_index

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The following operations can cause downtime or errors:
 - renaming a column
 - removing a column
 - adding an index non-concurrently (Postgres only)
+- removing an index non-concurrently (Postgres only)
 - adding a `json` column to an existing table (Postgres only)
 
 For more info, check out:
@@ -125,7 +126,20 @@ class AddSomeIndexToUsers < ActiveRecord::Migration
   end
 end
 ```
+### Removing an index (Postgres)
 
+Remove indexes concurrently.
+
+```ruby
+class RemoveEmailIndexFromUsers < ActiveRecord::Migration
+  def change
+    commit_db_transaction
+    safety_assured
+      execute 'DROP INDEX CONCURRENTLY IF EXISTS index_users_email'
+    end
+  end
+end
+```
 ### Adding a json column (Postgres)
 
 There’s no equality operator for the `json` column type, which causes issues for `SELECT DISTINCT` queries. Replace all calls to `uniq` with a custom scope.

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -35,6 +35,10 @@ module StrongMigrations
           if postgresql? && options[:algorithm] != :concurrently && !@new_tables.to_a.include?(args[0].to_s)
             raise_error :add_index
           end
+        when :remove_index
+          if postgresql?
+            raise_error :remove_index
+          end
         when :add_column
           type = args[2]
           options = args[3] || {}
@@ -168,6 +172,15 @@ Once that's deployed, wrap this step in a safety_assured { ... } block."
 "Adding an index with more than three columns only helps on extremely large tables.
 
 If you're sure this is what you want, wrap it in a safety_assured { ... } block."
+        when :remove_index
+"Removing an index non-concurrently locks the table. Instead, use:
+
+  def change
+    safety_assured
+      commit_db_transaction
+      execute 'DROP INDEX CONCURRENTLY IF EXISTS index_name'
+    end
+  end"
         when :change_table
 "The strong_migrations gem does not support inspecting what happens inside a
 change_table block, so cannot help you here. Please make really sure that what


### PR DESCRIPTION
Removing an index also puts a lock on the table in postgresql. Unfortunately, rails doesn't allow us to pass `algorithm: concurrently` into the `remove_index` option so we can't be as robust as the `add_index` warning. The solution is to execute it raw.

Let me know your thoughts, love the gem!