### PR TITLE
[Idea] Allow defining a custom header above error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ To customize specific messages, create an initializer with:
 StrongMigrations.error_messages[:add_column_default] = "Your custom instructions"
 ```
 
+To additionally prepend a custom message above all errors, define the `:custom_header` key:
+
+```ruby
+StrongMigrations.error_messages[:custom_header] = "Your custom header"
+```
+
 Check the [source code](https://github.com/ankane/strong_migrations/blob/master/lib/strong_migrations.rb) for the list of keys.
 
 ## Analyze Tables (Postgres)

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -111,7 +111,7 @@ module StrongMigrations
      \/  \/_/    \_\_____|  |_|  (_)  #strong_migrations
 
 '
-      custom_header = StrongMigrations.error_messages[custom_header]
+      custom_header = StrongMigrations.error_messages[:custom_header]
       message = StrongMigrations.error_messages[message_key] || "Missing message"
       raise StrongMigrations::UnsafeMigration, "#{wait_message}#{custom_header}\n\n#{message}\n"
     end

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -111,8 +111,9 @@ module StrongMigrations
      \/  \/_/    \_\_____|  |_|  (_)  #strong_migrations
 
 '
+      custom_header = StrongMigrations.error_messages[custom_header]
       message = StrongMigrations.error_messages[message_key] || "Missing message"
-      raise StrongMigrations::UnsafeMigration, "#{wait_message}#{message}\n"
+      raise StrongMigrations::UnsafeMigration, "#{wait_message}#{custom_header}\n\n#{message}\n"
     end
   end
 end


### PR DESCRIPTION
Some organizations may wish to explain why their particular CI & deployment architecture requires heeding the advice in this gem.

Configuring this in the initializer:

```ruby
StrongMigrations.error_messages[:custom_header] = "AHOY! We still serve requests on other instances during a migration. Because of this your migration will likely cause data loss. To remediate:"
```

Produces this:

```
  __          __     _____ _______ _
  \ \        / /\   |_   _|__   __| |
   \ \  /\  / /  \    | |    | |  | |
    \ \/  \/ / /\ \   | |    | |  | |
     \  /\  / ____ \ _| |_   | |  |_|
      \/  \/_/    \_\_____|  |_|  (_)  #strong_migrations
 
AHOY! We still serve requests on other instances during a migration. Because of this your migration will likely cause data loss. To remediate:

If you really have to:

1. Create a new table
2. Write to both tables
3. Backfill data from the old table to new table
4. Move reads from the old table to the new table
5. Stop writing to the old table
6. Drop the old table
```