### PR TITLE
PostGISAdapter enhancements

### DIFF
--- a/lib/tasks/strong_migrations.rake
+++ b/lib/tasks/strong_migrations.rake
@@ -12,6 +12,9 @@ namespace :strong_migrations do
 
     require "strong_migrations/alphabetize_columns"
     ActiveRecord::Base.connection.class.prepend StrongMigrations::AlphabetizeColumns
+    if ActiveRecord::ConnectionAdapters.const_defined?('PostGISAdapter')
+      ActiveRecord::ConnectionAdapters::PostGISAdapter.prepend StrongMigrations::AlphabetizeColumns
+    end
     ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend StrongMigrations::AlphabetizeColumns
   end
 end


### PR DESCRIPTION
If `PostGISAdapter` is defined patch columns method with `StrongMigrations::AlphabetizeColumns` module.

PostGIS [includes](https://github.com/rgeo/activerecord-postgis-adapter/blob/master/lib/active_record/connection_adapters/postgis_adapter.rb#L39) their own schema statements which override the default columns implementation from Rails.