### PR TITLE
Change documentation on add_column_default

### DIFF
--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -18,11 +18,19 @@ module StrongMigrations
 the entire table to be rewritten.
 
 Instead, add the column without a default value,
-then change the default.
+then change the default, then make sure to backfill
+the data of existing rows.
 
   def up
     add_column :users, :some_column, :text
     change_column_default :users, :some_column, \"default_value\"
+    # Make sure to backfill the data
+    safety_assured do
+      execute %{
+        UPDATE users
+        SET some_column = \"default_value\"
+      }
+    end
   end
 
   def down

--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -22,7 +22,9 @@ then change the default, then make sure to backfill
 the data of existing rows in another migration.
 
 # First migration
-class AddSomeColumnToUsers < ActiveRecord::Migration[5.2]
+class AddSomeColumnToUsers < #{
+  ActiveRecord::VERSION::MAJOR > 5 ? "ActiveRecord::Migration[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]" : "ActiveRecord::Base"
+}
   def up
     add_column :users, :some_column, :text
     change_column_default :users, :some_column, \"default_value\"
@@ -34,7 +36,9 @@ class AddSomeColumnToUsers < ActiveRecord::Migration[5.2]
 end
 
 # Second migration
-class BackfillSomeColumn < ActiveRecord::Migration[5.2]
+class BackfillSomeColumn < #{
+  ActiveRecord::VERSION::MAJOR > 5 ? "ActiveRecord::Migration[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]" : "ActiveRecord::Base"
+}
   disable_ddl_transaction!
 
   def change


### PR DESCRIPTION
I was wondering if we could change the documentation of the error on `add_column_default` to a recommendation to backfill date on existing rows. `add_column_default` would have backfilled the data, so I think it's good to have an equivalent set of operations as a recommendation.