### PR TITLE
Consider change_column migration to change integer limit as a safe operation in Postgres

### DIFF
--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -52,10 +52,15 @@ module StrongMigrations
           end
         when :change_column
           safe = false
-          # assume Postgres 9.1+ since previous versions are EOL
-          if postgresql? && args[2].to_s == "text"
-            column = connection.columns(args[0]).find { |c| c.name.to_s == args[1].to_s }
-            safe = column && column.type == :string
+          # assume Postgres 9.3+ since previous versions are EOL
+          if postgresql?
+            if args[2].to_s == "text"
+              column = connection.columns(args[0]).find { |c| c.name.to_s == args[1].to_s }
+              safe = column && column.type == :string
+            elsif args[2].to_s == "integer" && !args[3][:limit].nil?
+              column = connection.columns(args[0]).find { |c| c.name.to_s == args[1].to_s }
+              safe = column && column.type == :integer
+            end
           end
           raise_error :change_column unless safe
         when :create_table

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -65,6 +65,12 @@ class ChangeColumn < TestMigration
   end
 end
 
+class ChangeColumnIntegerLimit < TestMigration
+  def change
+    change_column :users, :device_id, :integer, limit: 8
+  end
+end
+
 class ChangeColumnVarcharToText < TestMigration
   def change
     change_column :users, :name, :text
@@ -214,6 +220,11 @@ class StrongMigrationsTest < Minitest::Test
 
   def test_change_column
     assert_unsafe ChangeColumn
+  end
+
+  def test_change_column_integer_limit
+    skip unless postgres?
+    assert_safe ChangeColumnIntegerLimit
   end
 
   def test_change_column_varchar_to_text

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,6 +38,7 @@ class CreateUsers < TestMigration
   def change
     create_table "users" do |t|
       t.string :name
+      t.integer :device_id
     end
   end
 end


### PR DESCRIPTION
From `Postgres 9.2` [release notes](https://www.postgresql.org/docs/9.2/static/release-9-2.html):

```
Increasing the length limit for a varchar or varbit column, or removing the limit altogether, no longer requires a table rewrite. 

Similarly, increasing the allowable precision of a numeric column, or changing a column from constrained numeric to unconstrained numeric, no longer requires a table rewrite. 

Table rewrites are also avoided in similar cases involving the interval, timestamp, and timestamptz types.
```
At our company we use Postgres 9.6 and I was trying to write a migration that changes `integer` limit on a column from `4` to `8`, but `strong_migrations` raised error as this is assumed to be an unsafe migration because of `change_column`.
<img width="776" alt="screen shot 2018-10-09 at 11 18 30 am" src="https://user-images.githubusercontent.com/4034241/46649017-13697e80-cbb5-11e8-8685-b6717fff4dd6.png">


However, as it is clear from the release notes, it is safe to change integer limits from `Postgres 9.2+ `onwards, so I have made necessary changes to **not** raise error when such a migration is written.

Also, as per Postgres [release notes](https://www.postgresql.org/support/versioning/), EOL is now on verison 9.2 so I have made the assumption that Postgres version is 9.2+.