### PR TITLE
Add round brackets to be more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ class BackfillSomeColumn < ActiveRecord::Migration[5.2]
 
   def change
     # Rails 5+
-    User.in_batches.update_all some_column: "default_value"
+    User.in_batches.update_all(some_column: "default_value")
 
     # Rails < 5
     User.find_in_batches do |records|
-      User.where(id: records.map(&:id)).update_all some_column: "default_value"
+      User.where(id: records.map(&:id)).update_all(some_column: "default_value")
     end
   end
 end

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -180,9 +180,9 @@ module StrongMigrations
     def backfill_code(table, column, default)
       model = table.to_s.classify
       if ActiveRecord::VERSION::MAJOR >= 5
-        "#{model}.in_batches.update_all #{column}: #{default.inspect}"
+        "#{model}.in_batches.update_all(#{column}: #{default.inspect})"
       else
-        "#{model}.find_in_batches do |records|\n      #{model}.where(id: records.map(&:id)).update_all #{column}: #{default.inspect}\n    end"
+        "#{model}.find_in_batches do |records|\n      #{model}.where(id: records.map(&:id)).update_all(#{column}: #{default.inspect})\n    end"
       end
     end
 


### PR DESCRIPTION
I'm tired of updating migration when I see round brackets for `where` part and not for `update_all` method :)