### PR TITLE
allow add comment changes to otherwise unchanged columns

### DIFF
--- a/strong_migrations.gemspec
+++ b/strong_migrations.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "pg", "< 1"
+  spec.add_development_dependency "pry-byebug"
 end

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -83,6 +83,18 @@ class ChangeColumnNullNoDefault < TestMigration
   end
 end
 
+class ChangeColumnAddComment < TestMigration
+  def change
+    change_column :users, :name, :string, comment: "Some Comment"
+  end
+end
+
+class ChangeColumnAddCommentUnsafe < TestMigration
+  def change
+    change_column :users, :name, :text, comment: "Some Comment"
+  end
+end
+
 class ExecuteArbitrarySQL < TestMigration
   def change
     execute 'SELECT CURRENT_TIMESTAMP'
@@ -219,7 +231,11 @@ class Custom < TestMigration
   end
 end
 
-class StrongMigrationsTest < Minitest::Test
+class StrongMigrationsTest < Minitest::Spec
+  before do
+    clean_db
+  end
+
   def test_add_index
     skip unless postgres?
     assert_unsafe AddIndex
@@ -370,6 +386,14 @@ class StrongMigrationsTest < Minitest::Test
 
   def test_custom
     assert_unsafe Custom, "No foreign keys on the users table"
+  end
+
+  def test_add_comment_safe
+    assert_safe ChangeColumnAddComment
+  end
+
+  def test_add_comment_unsafe
+    assert_unsafe ChangeColumnAddCommentUnsafe
   end
 
   private

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -389,6 +389,7 @@ class StrongMigrationsTest < Minitest::Spec
   end
 
   def test_add_comment_safe
+    skip unless postgres?
     assert_safe ChangeColumnAddComment
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,9 +2,10 @@ require "bundler/setup"
 Bundler.require(:default)
 require "minitest/autorun"
 require "minitest/pride"
+require "minitest/spec"
 require "active_record"
 
-Minitest::Test = Minitest::Unit::TestCase unless defined?(Minitest::Test)
+# Minitest::Test = Minitest::Unit::TestCase unless defined?(Minitest::Test)
 
 adapter = ENV["ADAPTER"] || "postgres"
 ActiveRecord::Base.establish_connection("#{adapter}://localhost/strong_migrations_test")
@@ -31,9 +32,6 @@ end
 TestMigration = activerecord5? ? ActiveRecord::Migration[migration_version] : ActiveRecord::Migration
 TestSchema = ActiveRecord::Schema
 
-ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS users")
-ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS new_users")
-
 class CreateUsers < TestMigration
   def change
     create_table "users" do |t|
@@ -41,9 +39,16 @@ class CreateUsers < TestMigration
     end
   end
 end
-migrate CreateUsers
 
-class Minitest::Test
+def clean_db
+  ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS users")
+  ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS new_users")
+  migrate CreateUsers
+end
+
+clean_db
+
+class Minitest::Spec
   def postgres?
     ENV["ADAPTER"].nil?
   end


### PR DESCRIPTION
It is my understanding that adding a column annotation (comment) in postgres should be a safe migration. This PR allows that.

Please let me know if I missed anything, or if my understanding is off. Happy to make changes as need be and assist in maintaining this change.

Also, I added a db cleaner to run between tests since I was having some errors thrown from duplicate columns.

Thanks,
Alexi