### PR TITLE
Add check for validated foreign key constraint

### DIFF
--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -157,10 +157,10 @@ class Backfill%{migration_name} < ActiveRecord::Migration%{migration_suffix}
 end",
 
   add_foreign_key:
-"A new foreign key is validated by default. This aquires an AccessExclusiveLock
+"A new foreign key is validated by default. This acquires an AccessExclusiveLock
 which is expensive on large tables resulting in downtime. Instead, create an
 \"invalid\" foreign key constraint which may be explicitly validated later if
-necessary. The separate validation aquires a more agreeable RowShareLock.
+necessary. The separate validation acquires a more agreeable RowShareLock.
 
 class %{migration_name} < ActiveRecord::Migration%{migration_suffix}
   def change

--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -155,6 +155,18 @@ class Backfill%{migration_name} < ActiveRecord::Migration%{migration_suffix}
     %{code}
   end
 end",
+
+  add_foreign_key:
+"A new foreign key is validated by default. This aquires an AccessExclusiveLock
+which is expensive on large tables resulting in downtime. Instead, create an
+\"invalid\" foreign key constraint which may be explicitly validated later if
+necessary. The separate validation aquires a more agreeable RowShareLock.
+
+class %{migration_name} < ActiveRecord::Migration%{migration_suffix}
+  def change
+    %{code}
+  end
+end",
   }
 
   def self.add_check(&block)

--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -154,7 +154,7 @@ class Backfill%{migration_name} < ActiveRecord::Migration%{migration_suffix}
   def change
     %{code}
   end
-end"
+end",
   }
 
   def self.add_check(&block)

--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -164,7 +164,13 @@ necessary. The separate validation acquires a more agreeable RowShareLock.
 
 class %{migration_name} < ActiveRecord::Migration%{migration_suffix}
   def change
-    %{code}
+    %{add_foreign_key_code}
+  end
+end
+
+class ValidateForeignKey < ActiveRecord::Migration%{migration_suffix}
+  def change
+    %{validate_foreign_key_code}
   end
 end",
   }

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -148,8 +148,8 @@ end"
 
           if postgresql? && validated
             raise_error :add_foreign_key,
-              add_foreign_key_code: foreign_key_code(from_table, to_table),
-              validate_foreign_key_code: validation_code(from_table, to_table)
+              add_foreign_key_code: command_str(:add_foreign_key, [from_table, to_table, validate: false]),
+              validate_foreign_key_code: command_str(:validate_foreign_key, [from_table, to_table])
           end
         end
 
@@ -232,18 +232,6 @@ end"
     def manual_validate_foreign_key_code(from_table, to_table)
       <<~CODE.strip
         ALTER TABLE #{from_table} VALIDATE CONSTRAINT fk_#{from_table}_#{to_table};
-      CODE
-    end
-
-    def foreign_key_code(from_table, to_table)
-      <<~CODE.strip
-        #{command_str(:add_foreign_key, [from_table, to_table, validate: false])}
-      CODE
-    end
-
-    def validation_code(from_table, to_table)
-      <<~CODE.strip
-        #{command_str(:validate_foreign_key, [from_table, to_table])}
       CODE
     end
 

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -139,8 +139,7 @@ end"
           options ||= {}
           validated = options.fetch(:validate) { true }
 
-          five_point_two = Gem::Version.new("5.2")
-          if postgresql? && ActiveRecord.version < five_point_two
+          if postgresql? && ActiveRecord::VERSION::MAJOR > 5 || (ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 2)
             raise_error :add_foreign_key,
               add_foreign_key_code: manual_add_foreign_key_code(from_table, to_table),
               validate_foreign_key_code: manual_validate_foreign_key_code(from_table, to_table)

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -141,7 +141,8 @@ end"
 
           if postgresql? && validated
             raise_error :add_foreign_key,
-              code: foreign_key_code(from_table, to_table)
+              add_foreign_key_code: foreign_key_code(from_table, to_table),
+              validate_foreign_key_code: validation_code(from_table, to_table)
           end
         end
 
@@ -218,7 +219,12 @@ end"
     def foreign_key_code(from_table, to_table)
       <<~CODE.strip
         #{command_str(:add_foreign_key, [from_table, to_table, validate: false])}
-            #{command_str(:validate_foreign_key, [from_table, to_table])}
+      CODE
+    end
+
+    def validation_code(from_table, to_table)
+      <<~CODE.strip
+        #{command_str(:validate_foreign_key, [from_table, to_table])}
       CODE
     end
 

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -139,7 +139,7 @@ end"
           options ||= {}
           validated = options.fetch(:validate) { true }
 
-          if validated
+          if postgresql? && validated
             raise_error :add_foreign_key,
               code: foreign_key_code(from_table, to_table)
           end

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -134,6 +134,14 @@ end"
             raise_error :change_column_null,
               code: backfill_code(table, column, default)
           end
+        when :add_foreign_key
+          from_table, to_table, options = args
+          options ||= Hash.new
+          validated = options.fetch(:validate) { true }
+
+          if validated
+            raise_error :add_foreign_key
+          end
         end
 
         StrongMigrations.checks.each do |check|

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -140,7 +140,8 @@ end"
           validated = options.fetch(:validate) { true }
 
           if validated
-            raise_error :add_foreign_key
+            raise_error :add_foreign_key,
+              code: foreign_key_code(from_table, to_table)
           end
         end
 
@@ -211,6 +212,24 @@ end"
         "#{model}.in_batches.update_all #{column}: #{default.inspect}"
       else
         "#{model}.find_in_batches do |records|\n      #{model}.where(id: records.map(&:id)).update_all #{column}: #{default.inspect}\n    end"
+      end
+    end
+
+    def foreign_key_code(from_table, to_table)
+      if ActiveRecord::VERSION::MAJOR > 5 || ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 2
+        <<~CODE.strip
+          #{command_str(:add_foreign_key, [from_table, to_table, validate: false])}
+              #{command_str(:validate_foreign_key, [from_table, to_table])}
+        CODE
+      else
+        <<~CODE.strip
+          safety_assured {
+                execute <<~SQL
+                  ALTER TABLE #{from_table} ADD CONSTRAINT fk_#{from_table}_#{to_table} FOREIGN KEY (#{to_table.to_s.singularize}_id) REFERENCES #{to_table} (id) NOT VALID;
+                  ALTER TABLE #{from_table} VALIDATE CONSTRAINT fk_#{from_table}_#{to_table};
+                SQL
+              }
+        CODE
       end
     end
 

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -216,21 +216,10 @@ end"
     end
 
     def foreign_key_code(from_table, to_table)
-      if ActiveRecord::VERSION::MAJOR > 5 || ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 2
-        <<~CODE.strip
-          #{command_str(:add_foreign_key, [from_table, to_table, validate: false])}
-              #{command_str(:validate_foreign_key, [from_table, to_table])}
-        CODE
-      else
-        <<~CODE.strip
-          safety_assured {
-                execute <<~SQL
-                  ALTER TABLE #{from_table} ADD CONSTRAINT fk_#{from_table}_#{to_table} FOREIGN KEY (#{to_table.to_s.singularize}_id) REFERENCES #{to_table} (id) NOT VALID;
-                  ALTER TABLE #{from_table} VALIDATE CONSTRAINT fk_#{from_table}_#{to_table};
-                SQL
-              }
-        CODE
-      end
+      <<~CODE.strip
+        #{command_str(:add_foreign_key, [from_table, to_table, validate: false])}
+            #{command_str(:validate_foreign_key, [from_table, to_table])}
+      CODE
     end
 
     def stop!(message, header: "Custom check")

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -136,7 +136,7 @@ end"
           end
         when :add_foreign_key
           from_table, to_table, options = args
-          options ||= Hash.new
+          options ||= {}
           validated = options.fetch(:validate) { true }
 
           if validated

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -225,7 +225,7 @@ end
 
 class Custom < TestMigration
   def change
-    add_foreign_key :users, :other, validate: false
+    add_column :users, :forbidden, :string
   end
 end
 
@@ -383,7 +383,7 @@ class StrongMigrationsTest < Minitest::Test
   end
 
   def test_custom
-    assert_unsafe Custom, "No foreign keys on the users table"
+    assert_unsafe Custom, "Cannot add forbidden column"
   end
 
   private

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -217,6 +217,12 @@ class VersionUnsafe < TestMigration
   end
 end
 
+class AddForeignKey < TestMigration
+  def change
+    add_foreign_key :users, :other
+  end
+end
+
 class Custom < TestMigration
   def change
     add_foreign_key :users, :other, validate: false
@@ -370,6 +376,10 @@ class StrongMigrationsTest < Minitest::Test
   def test_down
     assert_safe SafeUp
     assert_safe SafeUp, direction: :down
+  end
+
+  def test_add_foreign_key
+    assert_unsafe AddForeignKey
   end
 
   def test_custom

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -219,7 +219,7 @@ end
 
 class Custom < TestMigration
   def change
-    add_foreign_key :users, :other
+    add_foreign_key :users, :other, validate: false
   end
 end
 

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -379,6 +379,7 @@ class StrongMigrationsTest < Minitest::Test
   end
 
   def test_add_foreign_key
+    skip unless postgres?
     assert_unsafe AddForeignKey
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,8 +51,8 @@ class Minitest::Test
 end
 
 StrongMigrations.add_check do |method, args|
-  if method == :add_foreign_key && args[0].to_s == "users"
-    stop! "No foreign keys on the users table"
+  if method == :add_column && args[1].to_s == "forbidden"
+    stop! "Cannot add forbidden column"
   end
 end
 


### PR DESCRIPTION
Following #59, this PR adds a new check to protect against the addition of a validated foreign key constraint which acquires an AccessExclusiveLock which may result in significant performance problems on large, active tables.