### PR TITLE
Recommend installing in development only

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Catch unsafe migrations at dev time
 Add this line to your application’s Gemfile:
 
 ```ruby
-gem 'strong_migrations'
+gem "strong_migrations", group: :development
 ```
 
 ## How It Works


### PR DESCRIPTION
Update the Readme installation Gemfile code

This change makes the gemfile example code with the rest of the readme: specifically the very start:
> Catch unsafe migrations at dev time