### PR TITLE
Use version object

### DIFF
--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -15,8 +15,6 @@ module StrongMigrations
 
     def method_missing(method, *args, &block)
       unless @safe || ENV["SAFETY_ASSURED"] || is_a?(ActiveRecord::Schema) || @direction == :down || version_safe?
-        ar5 = ActiveRecord.version >= Gem::Version.new("5.0")
-
         case method
         when :remove_column, :remove_columns, :remove_timestamps, :remove_reference, :remove_belongs_to
           columns =
@@ -152,6 +150,10 @@ end"
 
     private
 
+    def ar5
+      ActiveRecord.version >= Gem::Version.new("5.0")
+    end
+
     def postgresql?
       %w(PostgreSQL PostGIS).include?(connection.adapter_name)
     end
@@ -167,7 +169,6 @@ end"
     def raise_error(message_key, header: nil, **vars)
       message = StrongMigrations.error_messages[message_key] || "Missing message"
 
-      ar5 = ActiveRecord.version >= Gem::Version.new("5.0")
       vars[:migration_name] = self.class.name
       vars[:migration_suffix] = ar5 ? "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]" : ""
       vars[:base_model] = ar5 ? "ApplicationRecord" : "ActiveRecord::Base"

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -15,7 +15,7 @@ module StrongMigrations
 
     def method_missing(method, *args, &block)
       unless @safe || ENV["SAFETY_ASSURED"] || is_a?(ActiveRecord::Schema) || @direction == :down || version_safe?
-        ar5 = ActiveRecord::VERSION::MAJOR >= 5
+        ar5 = ActiveRecord.version >= Gem::Version.new("5.0")
 
         case method
         when :remove_column, :remove_columns, :remove_timestamps, :remove_reference, :remove_belongs_to
@@ -167,7 +167,7 @@ end"
     def raise_error(message_key, header: nil, **vars)
       message = StrongMigrations.error_messages[message_key] || "Missing message"
 
-      ar5 = ActiveRecord::VERSION::MAJOR >= 5
+      ar5 = ActiveRecord.version >= Gem::Version.new("5.0")
       vars[:migration_name] = self.class.name
       vars[:migration_suffix] = ar5 ? "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]" : ""
       vars[:base_model] = ar5 ? "ApplicationRecord" : "ActiveRecord::Base"
@@ -199,7 +199,7 @@ end"
 
     def backfill_code(table, column, default)
       model = table.to_s.classify
-      if ActiveRecord::VERSION::MAJOR >= 5
+      if ActiveRecord.version >= Gem::Version.new("5.0")
         "#{model}.in_batches.update_all #{column}: #{default.inspect}"
       else
         "#{model}.find_in_batches do |records|\n      #{model}.where(id: records.map(&:id)).update_all #{column}: #{default.inspect}\n    end"

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -335,7 +335,7 @@ class StrongMigrationsTest < Minitest::Test
 
   def test_add_reference_default
     skip unless postgres?
-    if ActiveRecord::VERSION::MAJOR >= 5
+    if ActiveRecord.version >= Gem::Version.new("5.0")
       assert_unsafe AddReferenceDefault
     else
       assert_safe AddReferenceDefault

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,7 +21,7 @@ def migrate(migration, direction: :up)
 end
 
 def activerecord5?
-  ActiveRecord::VERSION::MAJOR >= 5
+  ActiveRecord.version >= Gem::Version.new("5.0")
 end
 
 def migration_version


### PR DESCRIPTION
The current mechanism for checking ActiveRecord version has worked well to date. However in [#62](https://github.com/ankane/strong_migrations/pull/62/files#r270973854), we came up on a need for making some code conditional on a more specific version of the library. It's quite a bit easier to do this by comparing `Gem::Version` objects, but I got the feedback to keep things consistent.

So I'm proposing we change how things are done everywhere, so I can use `Gem::Version` in that PR 😄 