### PR TITLE
Allow setting StrongMigrations.target_postgresql_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,22 +61,22 @@ end
 
 1. Tell ActiveRecord to ignore the column from its cache
 
-  ```ruby
-  class User < ApplicationRecord
-    self.ignored_columns = ["some_column"]
-  end
-  ```
+```ruby
+class User < ApplicationRecord
+  self.ignored_columns = ["some_column"]
+end
+```
 
 2. Deploy code
 3. Write a migration to remove the column (wrap in `safety_assured` block)
 
-  ```ruby
-  class RemoveSomeColumnFromUsers < ActiveRecord::Migration[5.2]
-    def change
-      safety_assured { remove_column :users, :some_column }
-    end
+```ruby
+class RemoveSomeColumnFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured { remove_column :users, :some_column }
   end
-  ```
+end
+```
 
 4. Deploy and run migration
 
@@ -532,6 +532,14 @@ ALTER ROLE myuser SET lock_timeout = '10s';
 ```
 
 There’s also [a gem](https://github.com/gocardless/activerecord-safer_migrations) you can use for this.
+
+## Set Target Version (Postgres)
+
+If your staging/production database version is different from your development version, you can override your local settings to test against the production version. For example, adding a column with a default value is unsafe in PostgreSQL < v11. If you're running PostgreSQL 11 locally, but an earlier version in production, your migrations will run without issue in your development environment, only to fail in production. You can override your local version with the `target_postgresql_version` configuration option.
+
+```ruby
+  StrongMigrations.target_postgresql_version = 10.7
+```
 
 ## Bigint Primary Keys (Postgres & MySQL)
 

--- a/README.md
+++ b/README.md
@@ -61,22 +61,22 @@ end
 
 1. Tell ActiveRecord to ignore the column from its cache
 
-```ruby
-class User < ApplicationRecord
-  self.ignored_columns = ["some_column"]
-end
-```
+  ```ruby
+  class User < ApplicationRecord
+    self.ignored_columns = ["some_column"]
+  end
+  ```
 
 2. Deploy code
 3. Write a migration to remove the column (wrap in `safety_assured` block)
 
-```ruby
-class RemoveSomeColumnFromUsers < ActiveRecord::Migration[5.2]
-  def change
-    safety_assured { remove_column :users, :some_column }
+  ```ruby
+  class RemoveSomeColumnFromUsers < ActiveRecord::Migration[5.2]
+    def change
+      safety_assured { remove_column :users, :some_column }
+    end
   end
-end
-```
+  ```
 
 4. Deploy and run migration
 
@@ -535,10 +535,10 @@ There’s also [a gem](https://github.com/gocardless/activerecord-safer_migratio
 
 ## Set Target Version (Postgres)
 
-If your staging/production database version is different from your development version, you can override your local settings to test against the production version. For example, adding a column with a default value is unsafe in PostgreSQL < v11. If you're running PostgreSQL 11 locally, but an earlier version in production, your migrations will run without issue in your development environment, only to fail in production. You can override your local version with the `target_postgresql_version` configuration option.
+If your staging/production database version is different from your development version, you can override your local settings to test against the production version. For example, adding a column with a default value is unsafe in PostgreSQL < v11. If you're running PostgreSQL 11 locally, but an earlier version in production, your migrations will run without issue in your development environment but fail in production. You can override your local version with the `target_postgresql_version` configuration option in your initializer. Provide the major version number only.
 
 ```ruby
-  StrongMigrations.target_postgresql_version = 10.7
+  StrongMigrations.target_postgresql_version = 10
 ```
 
 ## Bigint Primary Keys (Postgres & MySQL)

--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -14,7 +14,6 @@ module StrongMigrations
   self.auto_analyze = false
   self.start_after = 0
   self.checks = []
-  self.target_postgresql_version = nil
   self.error_messages = {
     add_column_default:
 "Adding a column with a non-null default causes the entire table to be rewritten.
@@ -163,9 +162,6 @@ class Validate%{migration_name} < ActiveRecord::Migration%{migration_suffix}
     %{validate_foreign_key_code}
   end
 end",
-
-    target_postgresql_version_format:
-'Wrong format for target_postgresql_version (%{target_postgresql_version}). Use major.minor, major.minor.patch (e.g. "10.8", "9.6.13") versioning or a server_version_num integer (SHOW server_version_num; # => "100008")'
   }
 
   def self.add_check(&block)

--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -9,11 +9,12 @@ require "strong_migrations/version"
 
 module StrongMigrations
   class << self
-    attr_accessor :auto_analyze, :start_after, :checks, :error_messages
+    attr_accessor :auto_analyze, :start_after, :checks, :error_messages, :target_postgresql_version
   end
   self.auto_analyze = false
   self.start_after = 0
   self.checks = []
+  self.target_postgresql_version = nil
   self.error_messages = {
     add_column_default:
 "Adding a column with a non-null default causes the entire table to be rewritten.
@@ -162,6 +163,9 @@ class Validate%{migration_name} < ActiveRecord::Migration%{migration_suffix}
     %{validate_foreign_key_code}
   end
 end",
+
+    target_postgresql_version_format:
+'Wrong format for target_postgresql_version (%{target_postgresql_version}). Use major.minor, major.minor.patch (e.g. "10.8", "9.6.13") versioning or a server_version_num integer (SHOW server_version_num; # => "100008")'
   }
 
   def self.add_check(&block)

--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -206,20 +206,7 @@ end"
     def target_version
       return unless StrongMigrations.target_postgresql_version && rails_test_or_development?
 
-      target_version = StrongMigrations.target_postgresql_version
-      return target_version if target_version.to_i.to_s == target_version
-
-      semantics = target_version.split('.')
-      case semantics.length
-      when 2
-        return semantics.first.to_i * 10000 + semantics.last.to_i
-      when 3
-        return semantics.first.to_i * 10000 + semantics[1].to_i * 100 + semantics.last.to_i
-      else
-        raise_error :target_postgresql_version_format,
-          header: "Configuration Error",
-          target_postgresql_version: target_version
-      end
+      StrongMigrations.target_postgresql_version.to_i * 10000
     end
 
     def version_safe?

--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -192,7 +192,34 @@ end"
     end
 
     def postgresql_version
-      @postgresql_version ||= connection.execute("SHOW server_version_num").first["server_version_num"].to_i
+      @postgresql_version ||= target_version || connection.execute("SHOW server_version_num").first["server_version_num"].to_i
+    end
+
+    def rails_test_or_development?
+      if defined?(Rails)
+        Rails.env.test? || Rails.env.development?
+      else
+        false
+      end
+    end
+
+    def target_version
+      return unless StrongMigrations.target_postgresql_version && rails_test_or_development?
+
+      target_version = StrongMigrations.target_postgresql_version
+      return target_version if target_version.to_i.to_s == target_version
+
+      semantics = target_version.split('.')
+      case semantics.length
+      when 2
+        return semantics.first.to_i * 10000 + semantics.last.to_i
+      when 3
+        return semantics.first.to_i * 10000 + semantics[1].to_i * 100 + semantics.last.to_i
+      else
+        raise_error :target_postgresql_version_format,
+          header: "Configuration Error",
+          target_postgresql_version: target_version
+      end
     end
 
     def version_safe?

--- a/lib/strong_migrations/version.rb
+++ b/lib/strong_migrations/version.rb
@@ -1,3 +1,3 @@
 module StrongMigrations
-  VERSION = "0.4.1"
+  VERSION = "0.4.0"
 end

--- a/lib/strong_migrations/version.rb
+++ b/lib/strong_migrations/version.rb
@@ -1,3 +1,3 @@
 module StrongMigrations
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
Allows setting `StrongMigrations.target_postgresql_version` in an initializer that will override the local `postgresql_version` check. 

As described in https://github.com/ankane/strong_migrations/issues/75