### PR TITLE
Backfill code should be unscoped

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ class BackfillSomeColumn < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def change
-    User.in_batches do |relation|
+    User.unscoped.in_batches do |relation|
       relation.update_all some_column: "default_value"
       sleep(0.1) # throttle
     end

--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -247,7 +247,7 @@ end"
 
     def backfill_code(table, column, default)
       model = table.to_s.classify
-      "#{model}.in_batches do |relation| \n      relation.update_all #{column}: #{default.inspect}\n      sleep(0.1)\n    end"
+      "#{model}.unscoped.in_batches do |relation| \n      relation.update_all #{column}: #{default.inspect}\n      sleep(0.1)\n    end"
     end
   end
 end


### PR DESCRIPTION
## Context
If the model you're adding a column to has a default_scope (e.g. w/ soft deletion), the code to backfill won't update all rows. This can become a problem if you need to perform an unscoped query in the app and the default column is not set. This PR makes it so that **all** rows are updated.

## Change
- Add `unscoped` to backfill code

## Example
Given the following migration...
```rb
class AddDefaultColumn < ActiveRecord::Migration[5.0]
  def change
    add_column :users, :x, :string, default: '3'
  end
end
```

...it now reports the following message:
```
== 20190530211525 AddDefaultColumn: migrating =================================
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

=== Dangerous operation detected #strong_migrations ===

Adding a column with a non-null default causes the entire table to be rewritten.
Instead, add the column without a default value, then change the default.

class AddDefaultColumn < ActiveRecord::Migration[5.0]
  def up
    add_column :users, :x, :string
    change_column_default :users, :x, "3"
  end

  def down
    remove_column :users, :x
  end
end

Then backfill the existing rows in the Rails console or a separate migration with disable_ddl_transaction!.

class BackfillAddDefaultColumn < ActiveRecord::Migration[5.0]
  disable_ddl_transaction!

  def change
    User.unscoped.in_batches.update_all x: "3"
  end
end
```