### PR TITLE
Add `remove_index` checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following operations can cause downtime or errors:
 - [[+]](#adding-a-column-with-a-default-value) adding a column with a default value
 - [[+]](#backfilling-data) backfilling data
 - [[+]](#adding-an-index) adding an index non-concurrently
+- [[+]](#removing-an-index) removing an index non-concurrently
 - [[+]](#adding-a-reference) adding a reference
 - [[+]](#adding-a-foreign-key) adding a foreign key
 - [[+]](#renaming-or-changing-the-type-of-a-column) changing the type of a column
@@ -178,6 +179,36 @@ end
 ```
 
 If you forget `disable_ddl_transaction!`, the migration will fail. Also, note that indexes on new tables (those created in the same migration) don’t require this. Check out [gindex](https://github.com/ankane/gindex) to quickly generate index migrations without memorizing the syntax.
+
+### Removing an index
+
+#### Bad
+
+In Postgres, removing a non-concurrent index locks the table.
+
+```ruby
+class AddSomeIndexToUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :users, :some_column
+  end
+end
+```
+
+#### Good
+
+Remove indexes concurrently.
+
+```ruby
+class AddSomeIndexToUsers < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :users, :some_column, algorithm: :concurrently
+  end
+end
+```
+
+If you forget `disable_ddl_transaction!`, the migration will fail.
 
 ### Adding a reference
 

--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -117,6 +117,17 @@ end",
 "Adding a non-unique index with more than three columns rarely improves performance.
 Instead, start an index with columns that narrow down the results the most.",
 
+    remove_index:
+"Removing a non-concurrent index locks the table. Instead, use:
+
+class %{migration_name} < ActiveRecord::Migration%{migration_suffix}
+  disable_ddl_transaction!
+
+  def change
+    %{command}
+  end
+end",
+
     change_table:
 "Strong Migrations does not support inspecting what happens inside a
 change_table block, so cannot help you here. Please make really sure that what

--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -62,6 +62,13 @@ module StrongMigrations
           if postgresql? && options[:algorithm] != :concurrently && !@new_tables.include?(table.to_s)
             raise_error :add_index, command: command_str("add_index", [table, columns, options.merge(algorithm: :concurrently)])
           end
+        when :remove_index
+          table, _columns, options = args
+          options ||= {}
+
+          if postgresql? && options[:algorithm] != :concurrently && !@new_tables.include?(table.to_s)
+            raise_error :remove_index, command: command_str("remove_index", [table, columns, options.merge(algorithm: :concurrently)])
+          end
         when :add_column
           table, column, type, options = args
           options ||= {}

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -233,6 +233,12 @@ class Custom < TestMigration
   end
 end
 
+class RemoveIndex < TestMigration
+  def change
+    remove_index :new_users, :name
+  end
+end
+
 class StrongMigrationsTest < Minitest::Test
   def test_add_index
     skip unless postgres?
@@ -304,6 +310,11 @@ class StrongMigrationsTest < Minitest::Test
 
   def test_remove_columns
     assert_unsafe RemoveColumns
+  end
+
+  def test_remove_index
+    skip unless postgres?
+    assert_unsafe RemoveIndex
   end
 
   def test_remove_timestamps


### PR DESCRIPTION
We need this check because removing indexes locks the table as well. And it can be dangerous.
Thank you for the gem! It's very helpful.