### PR TITLE
Add check for deleting an index before creating the new one

### DIFF
--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -160,6 +160,14 @@ class Validate%{migration_name} < ActiveRecord::Migration%{migration_suffix}
     %{validate_foreign_key_code}
   end
 end",
+
+    dangerous_replace_index:
+"Dropping an old index before creating the new one might result in slow queries
+while building the new index.
+
+A safer approach could be to first create the new index and afterwards delete
+the old one.
+"
   }
 
   def self.add_check(&block)

--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -173,6 +173,13 @@ end"
         end
       end
 
+      remove_index_index = @ordered_migrations.index { |k| k.first == :remove_index }
+      add_index_index = @ordered_migrations.drop(remove_index_index).index { |k| k.first == :add_index } if remove_index_index.present?
+
+      if remove_index_index.present? && add_index_index
+        raise_error :dangerous_replace_index
+      end
+
       result = yield
 
       if StrongMigrations.auto_analyze && direction == :up && postgresql? && method == :add_index

--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -6,6 +6,7 @@ module StrongMigrations
       @migration = migration
       @new_tables = []
       @safe = false
+      @ordered_migrations = []
     end
 
     def safety_assured
@@ -19,6 +20,8 @@ module StrongMigrations
     end
 
     def perform(method, *args)
+      @ordered_migrations << [method, args]
+
       unless safe?
         case method
         when :remove_column, :remove_columns, :remove_timestamps, :remove_reference, :remove_belongs_to

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -239,6 +239,13 @@ class Custom < TestMigration
   end
 end
 
+class RemoveBeforeAddIndexTest < TestMigration
+  def change
+    remove_index :users, column: :city
+    add_index :users, [:name, :city], algorithm: :concurrently
+  end
+end
+
 class StrongMigrationsTest < Minitest::Test
   def test_add_index
     skip unless postgres?
@@ -410,6 +417,11 @@ class StrongMigrationsTest < Minitest::Test
 
   def test_custom
     assert_unsafe Custom, "Cannot add forbidden column"
+  end
+
+  def test_remove_before_add_index
+    skip unless postgres?
+    assert_unsafe RemoveBeforeAddIndexTest
   end
 
   private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,6 +46,8 @@ class CreateUsers < TestMigration
 
     create_table "orders" do |t|
     end
+
+    add_index "users", "city"
   end
 end
 migrate CreateUsers


### PR DESCRIPTION
When replacing an index in the database it's easy to not think about
the time between the deleting of the old index and creating the new one,
especially if it's on a large table. If it's a heavily used table, not
having an index will make the database spend a lot of time running those
queries until the new index is in place. This might break your web
server since most requests will timeout waiting on these queries to
complete and block other requests from coming through.

This adds a check to see if you're dropping the old index before you've
created the new one recommends creating the new index before dropping
the old one.

EDIT: Also, thanks for this awesome gem 😄