### PR TITLE
Add `AddTypeColumn` checker

### DIFF
--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -44,6 +44,9 @@ end%{append}",
 "There's no equality operator for the json column type, which
 causes issues for SELECT DISTINCT queries. Use jsonb instead.",
 
+    add_type_column:
+"Adding type column in migration might cause downtime.",
+
     change_column:
 "Changing the type of an existing column requires the entire
 table and indexes to be rewritten. A safer approach is to:

--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -93,6 +93,10 @@ end"
           if type.to_s == "json" && postgresql?
             raise_error :add_column_json
           end
+
+          if column == ActiveRecord::Base.inheritance_column.to_sym
+            raise_error :add_type_column
+          end
         when :change_column
           table, column, type = args
 

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -59,6 +59,24 @@ class AddColumnJson < TestMigration
   end
 end
 
+class AddTypeColumn < TestMigration
+  def change
+    add_column :users, :type, :string
+  end
+end
+
+class AddTypeColumnWhenInheritanceColumnIsNotType < TestMigration
+  def change
+    add_column :users, :type, :string
+  end
+end
+
+class AddInheritanceColumn < TestMigration
+  def change
+    add_column :users, :my_type, :string
+  end
+end
+
 class ChangeColumn < TestMigration
   def change
     change_column :users, :properties, :bad_name
@@ -281,6 +299,24 @@ class StrongMigrationsTest < Minitest::Test
   def test_add_column_json
     skip unless postgres?
     assert_unsafe AddColumnJson
+  end
+
+  def test_add_type_column
+    ActiveRecord::Base.inheritance_column = :type
+    assert_unsafe AddTypeColumn
+    ActiveRecord::Base.inheritance_column = :my_type
+  end
+
+  def test_add_type_column_when_inheritance_column_is_not_type
+    ActiveRecord::Base.inheritance_column = :my_type
+    assert_safe AddTypeColumnWhenInheritanceColumnIsNotType
+    ActiveRecord::Base.inheritance_column = :type
+  end
+
+  def test_add_inheritance_column
+    ActiveRecord::Base.inheritance_column = :my_type
+    assert_unsafe AddInheritanceColumn
+    ActiveRecord::Base.inheritance_column = :type
   end
 
   def test_change_column


### PR DESCRIPTION
`type` column is reserved by Rails and is used for STI.
Soon after `type` column is added, Rails looks for a subclass according to `type` column. This might cause downtime.