### PR TITLE
Allow foreign key additions to be safe in Postgres 11+

### DIFF
--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -142,7 +142,7 @@ end"
           options ||= {}
           validate = options.fetch(:validate, true)
 
-          if postgresql?
+          if postgresql? && postgresql_version < 110000
             if ActiveRecord::VERSION::STRING >= "5.2"
               if validate
                 raise_error :add_foreign_key,

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -393,26 +393,21 @@ class StrongMigrationsTest < Minitest::Test
   end
 
   def test_add_foreign_key
+    StrongMigrations.target_postgresql_version = 11
     assert_safe AddForeignKey
-  end
-
-  def test_add_foreign_key_before_pg_11
-    StrongMigrations.target_postgresql_version = 10
-    if postgres?
-      assert_unsafe AddForeignKey
-    else
-      assert_safe AddForeignKey
-    end
   ensure
     StrongMigrations.target_postgresql_version = nil
   end
 
   def test_add_foreign_key_safe
+    StrongMigrations.target_postgresql_version = 10
     if postgres? && ActiveRecord::VERSION::STRING <= "5.2"
       assert_unsafe AddForeignKeySafe
     else
       assert_safe AddForeignKeySafe
     end
+  ensure
+    StrongMigrations.target_postgresql_version = nil
   end
 
   def test_custom

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -393,6 +393,11 @@ class StrongMigrationsTest < Minitest::Test
   end
 
   def test_add_foreign_key
+    assert_safe AddForeignKey
+  end
+
+  def test_add_foreign_key_before_pg_11
+    StrongMigrations.target_postgresql_version = 10
     if postgres?
       assert_unsafe AddForeignKey
     else

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -403,6 +403,8 @@ class StrongMigrationsTest < Minitest::Test
     else
       assert_safe AddForeignKey
     end
+  ensure
+    StrongMigrations.target_postgresql_version = nil
   end
 
   def test_add_foreign_key_safe


### PR DESCRIPTION
In Postgres 11, adding a foreign key constraint requires a `SHARE ROW EXCLUSIVE` lock instead of an `ACCESS EXCLUSIVE` one ([docs](https://www.postgresql.org/docs/11/sql-altertable.html)).

It seems that when this check was added in #62, it was based on PG 10 or earlier?  Would appreciate any feedback.  

