### PR TITLE
Add spacing to hash - styling improvement

### DIFF
--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -265,8 +265,8 @@ end"
         if last_arg.any?
           str_args << last_arg.map do |k, v|
             if v.is_a?(Hash)
-              # pretty index: {algorithm: :concurrently}
-              "#{k}: {#{v.map { |k2, v2| "#{k2}: #{v2.inspect}" }.join(", ")}}"
+              # pretty index: { algorithm: :concurrently }
+              "#{k}: { #{v.map { |k2, v2| "#{k2}: #{v2.inspect}" }.join(", ")} }"
             else
               "#{k}: #{v.inspect}"
             end

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -193,7 +193,7 @@ end
 
 class AddReferenceConcurrently < TestMigration
   def change
-    add_reference :users, :ip, index: {algorithm: :concurrently}
+    add_reference :users, :ip, index: { algorithm: :concurrently }
   end
 end
 


### PR DESCRIPTION
According to https://github.com/rubocop-hq/ruby-style-guide#spaces-and-braces with spacing is better :)