### PR TITLE
Fix migration class name when displaying hints

### DIFF
--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -231,7 +231,7 @@ Then add the NOT NULL constraint."
 
       message = StrongMigrations.error_messages[message_key] || "Missing message"
 
-      vars[:migration_name] = self.class.name
+      vars[:migration_name] = @migration.class.name
       vars[:migration_suffix] = "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
       vars[:base_model] = "ApplicationRecord"
 

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -254,7 +254,17 @@ end
 class StrongMigrationsTest < Minitest::Test
   def test_add_index
     if postgres?
-      assert_unsafe AddIndex
+      assert_unsafe AddIndex, <<~EOF
+        Adding an index non-concurrently locks the table. Instead, use:
+
+        class AddIndex < ActiveRecord::Migration[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]
+          disable_ddl_transaction!
+
+          def change
+            add_index :users, :name, algorithm: :concurrently
+          end
+        end
+      EOF
     else
       assert_safe AddIndex
       assert_safe RemoveIndex


### PR DESCRIPTION
Before
<img width="656" alt="Screen Shot 2019-12-18 at 03 15 36" src="https://user-images.githubusercontent.com/5657035/71047578-c7b14e00-2144-11ea-8a20-29acd18a7955.png">
