### PR TITLE
Add add_foreign_key_concurrently migration helper

### DIFF
--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -3,6 +3,7 @@ require "active_support"
 require "strong_migrations/checker"
 require "strong_migrations/database_tasks"
 require "strong_migrations/migration"
+require "strong_migrations/migration_helpers"
 require "strong_migrations/railtie" if defined?(Rails)
 require "strong_migrations/unsafe_migration"
 require "strong_migrations/version"
@@ -174,18 +175,15 @@ end",
 
     add_foreign_key:
 "New foreign keys are validated by default. This acquires an AccessExclusiveLock,
-which is expensive on large tables. Instead, validate it in a separate migration
+which is expensive on large tables. To work around this, you can use `add_foreign_key_concurrently`
+helper. This method ensures that no downtime is needed. It will create foreign key and validate it separately
 with a more agreeable RowShareLock.
 
 class %{migration_name} < ActiveRecord::Migration%{migration_suffix}
-  def change
-    %{add_foreign_key_code}
-  end
-end
+  disable_ddl_transaction!
 
-class Validate%{migration_name} < ActiveRecord::Migration%{migration_suffix}
   def change
-    %{validate_foreign_key_code}
+    %{command}
   end
 end",
   }
@@ -218,5 +216,6 @@ ActiveSupport.on_load(:active_record) do
 
   if defined?(ActiveRecord::Tasks::DatabaseTasks)
     ActiveRecord::Tasks::DatabaseTasks.singleton_class.prepend(StrongMigrations::DatabaseTasks)
+    ActiveRecord::Migration.include(StrongMigrations::MigrationHelpers)
   end
 end

--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -156,24 +156,9 @@ Then add the NOT NULL constraint."
           validate = options.fetch(:validate, true)
 
           if postgresql?
-            if ActiveRecord::VERSION::STRING >= "5.2"
-              if validate
-                raise_error :add_foreign_key,
-                  add_foreign_key_code: command_str("add_foreign_key", [from_table, to_table, options.merge(validate: false)]),
-                  validate_foreign_key_code: command_str("validate_foreign_key", [from_table, to_table])
-              end
-            else
-              # always validated before 5.2
-
-              # fk name logic from rails
-              primary_key = options[:primary_key] || "id"
-              column = options[:column] || "#{to_table.to_s.singularize}_id"
-              hashed_identifier = Digest::SHA256.hexdigest("#{from_table}_#{column}_fk").first(10)
-              fk_name = options[:name] || "fk_rails_#{hashed_identifier}"
-
+            if ActiveRecord::VERSION::STRING < "5.2" || validate
               raise_error :add_foreign_key,
-                add_foreign_key_code: constraint_str("ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s) NOT VALID", [from_table, fk_name, column, to_table, primary_key]),
-                validate_foreign_key_code: constraint_str("ALTER TABLE %s VALIDATE CONSTRAINT %s", [from_table, fk_name])
+                command: command_str(:add_foreign_key_concurrently, [from_table, to_table, options])
             end
           end
         end

--- a/lib/strong_migrations/migration_helpers.rb
+++ b/lib/strong_migrations/migration_helpers.rb
@@ -1,0 +1,84 @@
+module StrongMigrations
+  module MigrationHelpers
+
+    # Adds a new foreign key with minimal impact on concurrent updates.
+    #
+    # Example:
+    #
+    #     add_foreign_key_concurrently :articles, :authors
+    #
+    # Refer to Rails' `add_foreign_key` for more info on available options.
+    def add_foreign_key_concurrently(from_table, to_table, options = {})
+      ensure_postgresql(__method__)
+      ensure_not_in_transaction(__method__)
+
+      if ActiveRecord::VERSION::STRING >= "5.2"
+        add_foreign_key(from_table, to_table, options.merge(validate: false))
+        validate_foreign_key(from_table, to_table)
+      else
+        options = foreign_key_options(from_table, to_table, options)
+
+        safety_assured do
+          fk_name, column, primary_key = options.values_at(:name, :column, :primary_key)
+          primary_key ||= "id"
+
+          reversible do |dir|
+            dir.up do
+              execute quote_identifiers(<<~SQL, [from_table, fk_name, column, to_table, primary_key])
+                ALTER TABLE %s
+                ADD CONSTRAINT %s
+                FOREIGN KEY (%s)
+                REFERENCES %s (%s)
+                #{on_delete_update_statement(:delete, options[:on_delete])}
+                #{on_delete_update_statement(:update, options[:on_update])}
+                NOT VALID;
+              SQL
+
+              execute quote_identifiers("ALTER TABLE %s VALIDATE CONSTRAINT %s;", [from_table, fk_name])
+            end
+
+            dir.down do
+              remove_foreign_key(from_table, to_table)
+            end
+          end
+        end
+      end
+    end
+
+    private
+
+    def ensure_postgresql(method_name)
+      raise "`#{method_name}` is intended for Postgres usage only" unless postgresql?
+    end
+
+    def postgresql?
+      %w(PostgreSQL PostGIS).include?(connection.adapter_name)
+    end
+
+    def ensure_not_in_transaction(method_name)
+      if transaction_open?
+        raise <<~EOF
+          Cannot run `#{method_name}` inside a transaction.
+          To disable the transaction wrapping this migration, you can use `disable_ddl_transaction!`.
+        EOF
+      end
+    end
+
+    def on_delete_update_statement(delete_or_update, action)
+      delete_or_update = delete_or_update.to_s
+
+      case action
+      when nil, ""
+        ""
+      when :nullify
+        "ON #{delete_or_update.upcase} SET NULL"
+      else
+        "ON #{delete_or_update.upcase} #{action.upcase}"
+      end
+    end
+
+    def quote_identifiers(statement, identifiers)
+      statement % identifiers.map { |v| connection.quote_table_name(v) }
+    end
+  end
+end

--- a/test/migration_helpers_test.rb
+++ b/test/migration_helpers_test.rb
@@ -1,0 +1,59 @@
+require_relative "test_helper"
+
+class AddForeignKeyConcurrently < TestMigration
+  disable_ddl_transaction!
+
+  def change
+    add_foreign_key_concurrently :users, :orders
+  end
+end
+
+class MigrationHelpersTest < Minitest::Test
+  def setup
+    @connection = ActiveRecord::Base.connection
+  end
+
+  def test_add_foreign_key_concurrently_raises_for_non_postgres
+    skip if postgres?
+    error = assert_raises(RuntimeError) { migrate(AddForeignKeyConcurrently) }
+    assert_match "Postgres usage only", error.message
+  end
+
+  def test_add_foreign_key_concurrently_raises_inside_transaction
+    skip unless postgres?
+    migration = Class.new(TestMigration) do
+      def change
+        add_foreign_key_concurrently :users, :orders
+      end
+    end
+
+    error = assert_raises(RuntimeError) { migrate_inside_transaction(migration) }
+    assert_match "Cannot run `add_foreign_key_concurrently` inside a transaction", error.message
+  end
+
+  def test_add_foreign_key_concurrently
+    skip unless postgres?
+    migrate(AddForeignKeyConcurrently)
+
+    foreign_keys = @connection.foreign_keys("users")
+    assert_equal 1, foreign_keys.size
+
+    fk = foreign_keys.first
+    assert_equal "users", fk.from_table
+    assert_equal "orders", fk.to_table
+    assert_equal "order_id", fk.column
+    assert_equal "id", fk.primary_key
+    assert_equal "fk_rails_c1e9b98e31", fk.name
+  ensure
+    migrate(AddForeignKeyConcurrently, direction: :down) if postgres?
+  end
+
+  private
+
+  # Emulate running migration using `rake db:migrate`
+  def migrate_inside_transaction(migration)
+    ActiveRecord::Base.transaction do
+      migrate(migration)
+    end
+  end
+end


### PR DESCRIPTION
This method is not needed for mysql. So should this be a no-op for mysql or is it enough that only postgres is mentioned for foreign keys section in readme?