### PR TITLE
Experimental support for SQL migration inspection on Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Added experimental support for safety checking raw SQL migrations on Postgres with the `inspect_sql_postgresql` option
+
 ## 0.6.8 (2020-05-13)
 
 - `change_column_null` on a column with a `NOT NULL` constraint is safe in Postgres 12+

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,9 @@ source "https://rubygems.org"
 gemspec
 
 gem "activerecord", "~> 6.0.0"
+
+group :development, :test do
+  gem "pg_query", "~> 1.2"
+  gem "pry-byebug"
+  gem "awesome_print"
+end

--- a/README.md
+++ b/README.md
@@ -676,6 +676,22 @@ SAFETY_ASSURED=1 rails db:drop
 
 We recommend using a [separate database user](https://ankane.org/postgres-users) for migrations when possible so you don’t need to grant your app user permission to alter tables.
 
+### Inspect SQL
+
+Experimental support for checking the safety of raw SQL migrations on Postgres. This opt-in feature can be enabled with:
+
+```
+StrongMigrations.inspect_sql_postgresql = true
+```
+
+If enabled, you must add the [`pg_query`](https://github.com/lfittl/pg_query) gem to your Gemfile and ensure that the gem is required.
+
+```
+gem "pg_query", "~> 1.2", require: true # Assuming this is in a group that you've asked Bundler to require
+```
+
+The only currently supported checks are adding foreign key and check constraints without the `NOT VALID` option. If the checker can't determine whether the SQL is safe, it will fall back to assuming it isn't.
+
 ## Additional Reading
 
 - [Rails Migrations with No Downtime](https://pedro.herokuapp.com/past/2011/7/13/rails_migrations_with_no_downtime/)

--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -17,7 +17,7 @@ module StrongMigrations
   class << self
     attr_accessor :auto_analyze, :start_after, :checks, :error_messages,
       :target_postgresql_version, :target_mysql_version, :target_mariadb_version,
-      :enabled_checks, :lock_timeout, :statement_timeout
+      :enabled_checks, :lock_timeout, :statement_timeout, :inspect_sql_postgresql
     attr_writer :lock_timeout_limit
   end
   self.auto_analyze = false
@@ -234,6 +234,21 @@ end"
     else
       false
     end
+  end
+
+  private def pg_query_present?
+    # TODO: should this try and see if the gem is available to require, or just
+    # whether the constant is defined?
+    defined?(PgQuery)
+  end
+
+  def inspect_sql_postgresql=(enabled)
+    if enabled && !pg_query_present?
+      raise ArgumentError, <<~MSG
+        You must add the pg_query gem to your Gemfile and require it to enable inspect_sql_postgresql
+      MSG
+    end
+    @inspect_sql_postgresql = enabled
   end
 end
 

--- a/test/migrations.rb
+++ b/test/migrations.rb
@@ -215,6 +215,32 @@ class ExecuteArbitrarySQL < TestMigration
   end
 end
 
+class AddFkWithSqlSafely < TestMigration
+  def up
+    execute <<~SQL
+      ALTER TABLE "users"
+      ADD CONSTRAINT fk_users_safely FOREIGN KEY ("order_id") REFERENCES orders ("id") ON DELETE NO ACTION ON UPDATE NO ACTION NOT VALID
+    SQL
+  end
+
+
+  def down
+    execute <<~SQL
+      ALTER TABLE "users"
+      DROP CONSTRAINT fk_users_safely
+    SQL
+  end
+end
+
+class AddFkWithSqlUnsafely < TestMigration
+  def change
+    execute <<~SQL
+      ALTER TABLE "users"
+      ADD CONSTRAINT fk_users_unsafely FOREIGN KEY ("order_id") REFERENCES orders ("id") ON DELETE NO ACTION ON UPDATE NO ACTION;
+    SQL
+  end
+end
+
 class RenameColumn < TestMigration
   def change
     rename_column :users, :properties, :bad_name

--- a/test/strong_migrations_test.rb
+++ b/test/strong_migrations_test.rb
@@ -394,6 +394,18 @@ class StrongMigrationsTest < Minitest::Test
     StrongMigrations.auto_analyze = false
   end
 
+  def test_with_inspect_sql_enabled_add_fk_safely
+    with_inspect_sql_postgresql_enabled do
+      assert_safe AddFkWithSqlSafely
+    end
+  end
+
+  def test_with_inspect_sql_enabled_add_fk_unsafely
+    with_inspect_sql_postgresql_enabled do
+      assert_unsafe AddFkWithSqlUnsafely
+    end
+  end
+
   private
 
   def with_start_after(start_after)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-Bundler.require(:default)
+Bundler.require(:default, :development)
 require "minitest/autorun"
 require "minitest/pride"
 require "active_record"
@@ -30,6 +30,14 @@ end
 
 def migration_version
   ActiveRecord.version.to_s.to_f
+end
+
+def with_inspect_sql_postgresql_enabled
+  original_setting = StrongMigrations.inspect_sql_postgresql
+  StrongMigrations.inspect_sql_postgresql = true
+  yield
+ensure
+  StrongMigrations.inspect_sql_postgresql = original_setting
 end
 
 TestMigration = ActiveRecord::Migration[migration_version]


### PR DESCRIPTION
Opening for feedback on the general idea.

This PR is a proof-of-concept for analysing the safety of raw SQL migrations
using [pg_query][1]. In this case, showing the safety of a `NOT VALID` foreign
key addition vs the unsafe option.

Thoughts? One obvious downside is that this is Postgres-specific, so MySQL users
would be out of luck. However, that probably shouldn't be a reason on its own to
not add support for Postgres. I think this could be adapted even to analyse the
SQL generated by the Rails migrations DSL methods too?

[1]: https://github.com/lfittl/pg_query