### PR TITLE
update readme to only install in development group

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Supports for PostgreSQL, MySQL, and MariaDB
 Add this line to your application’s Gemfile:
 
 ```ruby
-gem 'strong_migrations'
+gem 'strong_migrations', group: :development
 ```
 
 And run:


### PR DESCRIPTION
>Catch unsafe migrations in development

Seems no need to include this in production. 