### PR TITLE
Support multiple databases for `target_version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Support multiple databases for `target_version`
+
 ## 1.4.0 (2022-10-31)
 
 - Added check for `add_exclusion_constraint`

--- a/README.md
+++ b/README.md
@@ -818,6 +818,9 @@ If your development database version is different from production, you can speci
 
 ```ruby
 StrongMigrations.target_version = 10 # or "8.0.12", "10.3.2", etc
+
+# or if you use multiple databases (ActiveRecord 6.1+)
+StrongMigrations.target_version = { primary: 10, animals: 15.0 }
 ```
 
 The major version works well for Postgres, while the full version is recommended for MySQL and MariaDB.

--- a/test/misc_test.rb
+++ b/test/misc_test.rb
@@ -47,4 +47,83 @@ class MiscTest < Minitest::Test
       end
     end
   end
+
+  def test_target_version_multiple_dbs_below_6_1
+    skip if multiple_dbs?
+
+    with_target_version({ primary: 10, animals: 15.0 }) do
+      error = assert_raises(StrongMigrations::Error) do
+        assert_safe AddColumnDefault
+      end
+      assert_equal "StrongMigrations.target_version does not support multiple databases for ActiveRecord < 6.1", error.message
+    end
+  end
+
+  def test_target_version_multiple_dbs
+    skip unless multiple_dbs?
+
+    with_multiple_dbs do
+
+      safe_version = postgresql? ? 11 : (mysql? ? "8.0.12" : "10.3.2")
+      with_target_version({ primary: safe_version }) do
+        assert_safe AddColumnDefault
+      end
+
+      unsafe_version = postgresql? ? 10 : (mysql? ? "8.0.11" : "10.3.1")
+      with_target_version({ primary: unsafe_version }) do
+        assert_unsafe AddColumnDefault
+      end
+    end
+  end
+
+  def test_target_version_multiple_dbs_unconfigured
+    skip unless multiple_dbs?
+
+    with_multiple_dbs do
+      error = assert_raises(StrongMigrations::Error) do
+        with_target_version({ animals: 10 }) do
+          assert_safe AddColumnDefault
+        end
+      end
+      assert_equal "StrongMigrations.target_version is not configured for :primary", error.message
+    end
+  end
+
+  private
+
+  def with_multiple_dbs(&block)
+    previous_db_config =
+      if ar_version >= 6.1
+        ActiveRecord::Base.connection_db_config.configuration_hash
+      else
+        ActiveRecord::Base.connection_config
+      end
+
+    multi_db_config = {
+      "test" => {
+        "primary" => {
+          "adapter" => $adapter,
+          "database" => "strong_migrations_test"
+        },
+        "animals" => {
+          "adapter" => $adapter,
+          "database" => "animals_test"
+        }
+      }
+    }
+    ActiveRecord::Base.configurations = multi_db_config
+
+    ActiveRecord::Base.connects_to(database: { writing: :primary })
+    ActiveRecord::Base.connected_to(role: :writing, &block)
+  ensure
+    ActiveRecord::Base.establish_connection(previous_db_config)
+  end
+
+  def multiple_dbs?
+    ar_version >= 6.1
+  end
+
+  def ar_version
+    ActiveRecord::VERSION::STRING.to_f
+  end
 end


### PR DESCRIPTION
It is very WIP. It currently only allows to set different database versions via

```ruby
StrongMigrations.target_version = { primary: 10, animals: 11 }
```

Considerations:
* Proper testing needs to be added.
* I think, we should also allow other existing configurations to be extended to support multiple databases. There are 2 approaches I'm thinking about:
1) via hashes
```ruby
StrongMigrations.target_version = {primary: 10, animals: 11}
StrongMigrations.start_after = {primary: 20170101000000, animals: 20170101000123}
# ... other configs
``` 
2) via methods calling
```ruby
StrongMigrations.primary.target_version = 10
StrongMigrations.animals.target_version = 11

StrongMigrations.primary.start_after = 20170101000000
StrongMigrations.animals.start_after = 20170101000123

# ... other configs
```
* I haven't found a better way to detect specification names ("primary", "animals") within migrations than manually setting it via ENV within a custom rake task and make existing rails tasks to depend on it.