### PR TITLE
[idea] allow for enforcing reason for overriding with safety_assured

### DIFF
--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -19,13 +19,14 @@ module StrongMigrations
     attr_accessor :auto_analyze, :start_after, :checks, :error_messages,
       :target_postgresql_version, :target_mysql_version, :target_mariadb_version,
       :enabled_checks, :lock_timeout, :statement_timeout, :check_down, :target_version,
-      :safe_by_default
+      :safe_by_default, :require_safety_reason
     attr_writer :lock_timeout_limit
   end
   self.auto_analyze = false
   self.start_after = 0
   self.checks = []
   self.safe_by_default = false
+  self.require_safety_reason = false
   self.error_messages = {
     add_column_default:
 "Adding a column with a non-null default blocks %{rewrite_blocks} while the entire table is rewritten.

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -15,7 +15,8 @@ module StrongMigrations
     end
     ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
-    def safety_assured
+    def safety_assured(reason: nil)
+      raise StrongMigrations::Error, "Specify a reason to override safety checks" if reason.nil? && StrongMigrations.require_safety_reason
       strong_migrations_checker.safety_assured do
         yield
       end

--- a/test/migrations.rb
+++ b/test/migrations.rb
@@ -43,6 +43,12 @@ class AddIndexSafetyAssured < TestMigration
   end
 end
 
+class AddIndexSafetyAssuredReason < TestMigration
+  def change
+    safety_assured(reason: "this table is unused") { add_index :users, :city, name: "no_boom" }
+  end
+end
+
 class AddIndexNewTable < TestMigration
   def change
     create_table "new_users" do |t|

--- a/test/require_safety_reason_test.rb
+++ b/test/require_safety_reason_test.rb
@@ -1,0 +1,21 @@
+require_relative "test_helper"
+
+class RequireSafetyReasonTest < Minitest::Test
+  def setup
+    StrongMigrations.require_safety_reason = true
+  end
+
+  def teardown
+    StrongMigrations.require_safety_reason = false
+  end
+
+  def test_fail_without_reason
+    assert_raises(StrongMigrations::Error) do
+      migrate AddIndexSafetyAssured
+    end
+  end
+
+  def test_passes_with_reason
+    migrate AddIndexSafetyAssuredReason
+  end
+end


### PR DESCRIPTION
we're interested in requiring all migrations that override safety checks to explain why it is safe to do so ("this table is unused so a full table rewrite is fine", etc.). Having the rationale directly in the code helps reviewers and future readers understand why it was safe at that time (as opposed to an offline conversation)

This PR adds an optional `reason` arg to `safety_assured` and enforces that it must be provided if the `require_safety_reason` option is enabled. it's disabled by default for backwards compatibility

curious what you think. thanks!