### PR TITLE
update database_tasks for active record 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ gemspec
 
 gem "rake"
 gem "minitest", ">= 5"
-gem "activerecord", "~> 6.1.0"
+gem "activerecord", "~> 7.0.0.alpha2"
 gem "pg"
 gem "mysql2"

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ gemspec
 
 gem "rake"
 gem "minitest", ">= 5"
-gem "activerecord", "~> 7.0.0.alpha2"
+gem "activerecord", "~> 6.1.0"
 gem "pg"
 gem "mysql2"

--- a/lib/strong_migrations/database_tasks.rb
+++ b/lib/strong_migrations/database_tasks.rb
@@ -1,7 +1,7 @@
 module StrongMigrations
   module DatabaseTasks
     def migrate(*args)
-      super(args)
+      super
     rescue => e
       if e.cause.is_a?(StrongMigrations::Error)
         # strip cause and clean backtrace

--- a/lib/strong_migrations/database_tasks.rb
+++ b/lib/strong_migrations/database_tasks.rb
@@ -1,7 +1,7 @@
 module StrongMigrations
   module DatabaseTasks
-    def migrate(version = nil)
-      super(version)
+    def migrate(*args)
+      super(args)
     rescue => e
       if e.cause.is_a?(StrongMigrations::Error)
         # strip cause and clean backtrace

--- a/lib/strong_migrations/database_tasks.rb
+++ b/lib/strong_migrations/database_tasks.rb
@@ -1,7 +1,7 @@
 module StrongMigrations
   module DatabaseTasks
-    def migrate
-      super
+    def migrate(version = nil)
+      super(version)
     rescue => e
       if e.cause.is_a?(StrongMigrations::Error)
         # strip cause and clean backtrace


### PR DESCRIPTION
This PR concerns only rails app with minimum version 7, or said other way with ActiveRecord 7 minimum. 

This aims at fixing the multi db handling with the 'new' migrate method that can now have one argument => `version`
👉  https://github.com/rails/rails/blob/main/activerecord/lib/active_record/tasks/database_tasks.rb#L272