### PR TITLE
Support Rails-version-specific schemas as of Rails 7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.8.0 (unreleased)
 
-- Dropped support for Ruby < 2.6 and Active Record < 5.2
+- Dropped support for Ruby < 2.6 and Active Record < 6.1
+- Added support for Rails-version-specific schema dumps
 
 ## 0.7.9 (2021-12-15)
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec
 
-gem "rake"
-gem "minitest", ">= 5"
-gem "activerecord", "~> 7.0.0"
-gem "pg"
-gem "mysql2"
+gem 'activerecord', '>= 6.1'
+gem 'minitest', '>= 5'
+gem 'mysql2'
+gem 'pg'
+gem 'rake'

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -7,7 +7,7 @@ module StrongMigrations
     end
 
     def method_missing(method, *args)
-      return super if is_a?(ActiveRecord::Schema)
+      return super if schema_migration?
 
       strong_migrations_checker.perform(method, *args) do
         super
@@ -26,6 +26,13 @@ module StrongMigrations
     end
 
     private
+
+    def schema_migration?
+      is_a?(ActiveRecord::Schema) || (
+        Object.const_defined?('ActiveRecord::Schema::Definition') &&
+          is_a?(ActiveRecord::Schema::Definition)
+      )
+    end
 
     def strong_migrations_checker
       @strong_migrations_checker ||= StrongMigrations::Checker.new(self)

--- a/lib/strong_migrations/version.rb
+++ b/lib/strong_migrations/version.rb
@@ -1,3 +1,3 @@
 module StrongMigrations
-  VERSION = "0.7.9"
+  VERSION = '0.8.0'
 end

--- a/strong_migrations.gemspec
+++ b/strong_migrations.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.6"
 
-  spec.add_dependency "activerecord", ">= 5.2"
+  spec.add_dependency 'activerecord', '>= 6.1'
 end


### PR DESCRIPTION
This PR drops support for ActiveRecord < 6.1 and provide support for Rails 7.0.2, in which Rails-version-specific schema dumps were introduced.

(See https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#rails-version-is-now-included-in-the-active-record-schema-dump)