### PR TITLE
Explain NOT NULL DDL on MySQL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,17 @@ end
 
 #### Good - MySQL and MariaDB
 
-[Let us know](https://github.com/ankane/strong_migrations/issues/new) if you have a safe way to do this.
+MySQL 5.6 or later [supports online DDL for making a column NOT NULL](https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html#online-ddl-column-operations). To make sure the ALTER TABLE is online DDL, we can specify `ALGORITHM=INPLACE, LOCK=NONE`. If the DDL cannot perform online, it returns an error such as `ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE.`
+
+```ruby
+class SetSomeColumnNotNull < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      execute "ALTER TABLE users MODIFY COLUMN some_column data_type NOT NULL, ALGORITHM=INPLACE, LOCK=NONE"
+    end
+  end
+end
+```
 
 ### Executing SQL directly
 


### PR DESCRIPTION
MySQL 5.6 or later supports online DDL and it does not lock a table. This PR explains it in README.
(Please point out if my English is wrong or unnatural)

> To avoid accidentally making the table unavailable for reads, writes, or both, specify a clause on the [ALTER TABLE](https://dev.mysql.com/doc/refman/5.6/en/alter-table.html) statement such as LOCK=NONE (permit reads and writes) or LOCK=SHARED (permit reads).
(https://dev.mysql.com/doc/refman/5.6/en/innodb-online-ddl.html)
