### PR TITLE
Allow setting NOT NULL on MySQL with online DDL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ end
 
 :turtle: Safe by default available
 
-#### Bad
+#### Bad - Postgres
 
 Setting `NOT NULL` on an existing column blocks reads and writes while every row is checked.
 
@@ -432,7 +432,8 @@ end
 
 #### Good - MySQL and MariaDB
 
-[Let us know](https://github.com/ankane/strong_migrations/issues/new) if you have a safe way to do this.
+Using online DDL feature, we can set `NOT NULL` on an existing column without locking.
+MySQL 5.6 or later and MariaDB 10.0 or later support online DDL.
 
 ### Executing SQL directly
 

--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -19,7 +19,7 @@ module StrongMigrations
     attr_accessor :auto_analyze, :start_after, :checks, :error_messages,
       :target_postgresql_version, :target_mysql_version, :target_mariadb_version,
       :enabled_checks, :lock_timeout, :statement_timeout, :check_down, :target_version,
-      :safe_by_default
+      :safe_by_default, :target_mysql_sql_modes
     attr_writer :lock_timeout_limit
   end
   self.auto_analyze = false
@@ -194,8 +194,13 @@ class Validate%{migration_name} < ActiveRecord::Migration%{migration_suffix}
   end
 end",
 
-    change_column_null_mysql:
-"Setting NOT NULL on an existing column is not safe with your database engine.",
+    change_column_null_mysql_too_old:
+"MySQL or MariaDB is too old and does not support online DDL.
+Setting NOT NULL on an existing column without online DDL is not safe.",
+
+    change_column_null_mysql_non_strict_mode:
+"MySQL or MariaDB is not in strict mode and does not support online DDL.
+Setting NOT NULL on an existing column without online DDL is not safe.",
 
     add_foreign_key:
 "Adding a foreign key blocks writes on both tables. Instead,

--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -1,3 +1,5 @@
+require "set"
+
 module StrongMigrations
   class Checker
     include SafeMethods
@@ -266,7 +268,23 @@ Then add the foreign key in separate migrations."
                   validate_constraint_code: validate_constraint_code
               end
             elsif mysql? || mariadb?
-              raise_error :change_column_null_mysql
+              # does not support online DDL
+              if mysql? && mysql_version < Gem::Version.new("5.6")
+                raise_error :change_column_null_mysql_too_old
+              end
+
+              if mariadb? && mariadb_version < Gem::Version.new("10.0")
+                raise_error :change_column_null_mysql_too_old
+              end
+
+              unless mysql_strict_mode
+                raise_error :change_column_null_mysql_non_strict_mode
+              end
+
+              unless default.nil?
+                raise_error :change_column_null,
+                  code: backfill_code(table, column, default)
+              end
             elsif !default.nil?
               raise_error :change_column_null,
                 code: backfill_code(table, column, default)
@@ -592,6 +610,19 @@ Then add the foreign key in separate migrations."
       else
         false
       end
+    end
+
+    def mysql_sql_modes
+      sql_modes = if StrongMigrations.target_mysql_sql_modes
+        StrongMigrations.target_mysql_sql_modes
+      else
+        @sql_modes ||= connection.select_all("SELECT @@SESSION.sql_mode").first["@@SESSION.sql_mode"].split(",")
+      end
+      Set.new(sql_modes)
+    end
+
+    def mysql_strict_mode
+      mysql_sql_modes.include?("STRICT_ALL_TABLES") || mysql_sql_modes.include?("STRICT_TRANS_TABLES")
     end
   end
 end

--- a/test/change_column_null_test.rb
+++ b/test/change_column_null_test.rb
@@ -2,10 +2,24 @@ require_relative "test_helper"
 
 class ChangeColumnNullTest < Minitest::Test
   def test_basic
-    if postgresql? || mysql? || mariadb?
+    if postgresql?
       assert_unsafe ChangeColumnNull
-    else
-      assert_safe ChangeColumnNull
+    elsif mysql?
+      with_target_version("5.6.0") do
+        assert_safe ChangeColumnNull
+      end
+    elsif mariadb?
+      with_target_version("10.0.0") do
+        assert_safe ChangeColumnNull
+      end
+    end
+  end
+
+  def test_old_mysql
+    skip unless mysql? || mariadb?
+
+    with_target_version("5.5.0") do
+      assert_unsafe ChangeColumnNull
     end
   end
 
@@ -34,7 +48,17 @@ class ChangeColumnNullTest < Minitest::Test
   end
 
   def test_default
-    assert_unsafe ChangeColumnNullDefault
+    if postgresql?
+      assert_unsafe ChangeColumnNullDefault
+    elsif mysql?
+      with_target_version("5.6.0") do
+        assert_unsafe ChangeColumnNullDefault
+      end
+    elsif mariadb?
+      with_target_version("10.0.0") do
+        assert_unsafe ChangeColumnNullDefault
+      end
+    end
   end
 
   def test_constraint_methods
@@ -51,5 +75,21 @@ class ChangeColumnNullTest < Minitest::Test
     with_target_version(12) do
       assert_safe ChangeColumnNullQuoted
     end
+  end
+
+  def test_mysql_non_strict_mode
+    skip unless mysql? || mariadb?
+
+    version = if mysql?
+      "5.6.0"
+    elsif mariadb?
+      "10.0.0"
+    end
+
+    StrongMigrations.target_mysql_sql_modes = []
+    with_target_version(version) do
+      assert_unsafe ChangeColumnNull
+    end
+    StrongMigrations.target_mysql_sql_modes = nil
   end
 end


### PR DESCRIPTION
Discussion: https://github.com/ankane/strong_migrations/pull/175

This PR allows setting NOT NULL on MySQL.
If any of the following conditions meets, migration will be aborted:
* MySQL is older then 5.6 (Online DDL is supported on MySQL 5.6 or later)
* MariaDB is older then 10.0 (Online DDL is supported on MariaDB 5.6 or later)
* strict mode is not enabled
* default value is set