### PR TITLE
Check for PostgreSQL index corruption in all Rails environments

### DIFF
--- a/lib/strong_migrations/adapters/postgresql_adapter.rb
+++ b/lib/strong_migrations/adapters/postgresql_adapter.rb
@@ -155,11 +155,9 @@ module StrongMigrations
         select_all(query.squish).any?
       end
 
-      # only check in non-developer environments (where actual server version is used)
       def index_corruption?
         server_version >= Gem::Version.new("14.0") &&
-          server_version < Gem::Version.new("14.4") &&
-          !StrongMigrations.developer_env?
+          server_version < Gem::Version.new("14.4")
       end
 
       private

--- a/test/add_index_test.rb
+++ b/test/add_index_test.rb
@@ -84,10 +84,8 @@ class AddIndexTest < Minitest::Test
 
   def test_corruption
     skip unless postgresql?
-    outside_developer_env do
-      with_target_version(14.3) do
-        assert_unsafe AddIndexConcurrently, "can cause silent data corruption in Postgres 14.0 to 14.3"
-      end
+    with_target_version(14.3) do
+      assert_unsafe AddIndexConcurrently, "can cause silent data corruption in Postgres 14.0 to 14.3"
     end
   end
 end

--- a/test/safe_by_default_test.rb
+++ b/test/safe_by_default_test.rb
@@ -19,10 +19,8 @@ class SafeByDefaultTest < Minitest::Test
 
   def test_add_index_corruption
     skip unless postgresql?
-    outside_developer_env do
-      with_target_version(14.3) do
-        assert_unsafe AddIndex, "can cause silent data corruption in Postgres 14.0 to 14.3"
-      end
+    with_target_version(14.3) do
+      assert_unsafe AddIndex, "can cause silent data corruption in Postgres 14.0 to 14.3"
     end
   end
 


### PR DESCRIPTION
Previously, the PostgreSQL index corruption bug was checked only in
production environments.

However, this can cause the issue to go unnoticed up to the point where
a project tries to release to production and migrate the database. CI
systems often run in the Rails test environment causing this check to
silently be skipped. This scenario happened to a project of mine,
requiring quick action to undo a series of steps we thought were being
checked in CI.

Projects can continue to use the StrongMigrations.target_version setting
if their developer or test database version differs from production.