### PR TITLE
Link to working blog post

### DIFF
--- a/lib/tasks/strong_migrations.rake
+++ b/lib/tasks/strong_migrations.rake
@@ -1,5 +1,5 @@
 namespace :strong_migrations do
-  # https://www.pgrs.net/2008/03/13/alphabetize-schema-rb-columns/
+  # https://www.pgrs.net/2008/03/12/alphabetize-schema-rb-columns/
   task :alphabetize_columns do
     $stderr.puts "Dumping schema"
     ActiveRecord::Base.logger.level = Logger::INFO


### PR DESCRIPTION
I was snooping to learn how AlphabetizeColumns works, and tried the commented link. But looks like the date is one off.

https://www.pgrs.net/2008/03/13/alphabetize-schema-rb-columns/ leads to a 404 page

https://www.pgrs.net/2008/03/12/alphabetize-schema-rb-columns/ leads to the blog post.