### PR TITLE
Check for string column function defaults

### DIFF
--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -71,6 +71,8 @@ module StrongMigrations
           # and no longer eligible to be retried at migration level
           # okay to have false positives
           @committed = true
+        when :change_column_default
+          check_change_column_default(*args)
         end
 
         # custom checks

--- a/test/add_column_test.rb
+++ b/test/add_column_test.rb
@@ -40,6 +40,7 @@ class AddColumnTest < Minitest::Test
     # TODO check MySQL and MariaDB
     skip unless postgresql?
     assert_unsafe AddColumnDefaultCallable
+    assert_unsafe AddColumnDefaultFunction
   end
 
   def test_json

--- a/test/change_column_test.rb
+++ b/test/change_column_test.rb
@@ -224,6 +224,16 @@ class ChangeColumnTest < Minitest::Test
     assert_unsafe ChangeColumnWithNotNull
   end
 
+  def test_change_default_to_function
+    skip unless postgresql?
+    assert_unsafe ChangeColumnWithFunctionDefault
+    assert_unsafe ChangeColumnDefaultToFunctionFromTo
+    assert_unsafe ChangeColumnDefaultToFunctionUpDown
+    assert_unsafe ChangeColumnDefaultWithChangeTable
+    assert_unsafe ChangeColumnDefaultWithChangeTableAndChangeDefault
+    assert_unsafe ChangeColumnDefaultWithChangeTableAndChangeDefaultFromTo
+  end
+
   def with_time_zone
     ActiveRecord::Base.connection.execute("SET timezone = 'America/Los_Angeles'")
     yield

--- a/test/migrations/add_column.rb
+++ b/test/migrations/add_column.rb
@@ -23,6 +23,12 @@ class AddColumnDefaultCallable < TestMigration
   end
 end
 
+class AddColumnDefaultFunction < TestMigration
+  def change
+    add_column :users, :new_uuid, :uuid, default: "gen_random_uuid()"
+  end
+end
+
 class AddColumnJson < TestMigration
   def change
     add_column :users, :properties, :json

--- a/test/migrations/change_column.rb
+++ b/test/migrations/change_column.rb
@@ -383,3 +383,65 @@ class ChangeColumnWithNotNull < TestMigration
     change_column :users, :country, :string, limit: 20
   end
 end
+
+class ChangeColumnWithFunctionDefault < TestMigration
+  def up
+    change_column :users, :uuid, :uuid, default: "gen_random_uuid()"
+  end
+
+  def down
+    change_column :users, :uuid, :uuid, default: nil
+  end
+end
+
+class ChangeColumnDefaultToFunctionFromTo < TestMigration
+  def change
+    change_column_default :users, :uuid, from: nil, to: "gen_random_uuid()"
+  end
+end
+
+class ChangeColumnDefaultToFunctionUpDown < TestMigration
+  def up
+    change_column_default :users, :uuid, "gen_random_uuid()"
+  end
+
+  def down
+    change_column_default :users, :uuid, nil
+  end
+end
+
+class ChangeColumnDefaultWithChangeTable < TestMigration
+  def up
+    change_table :users do |t|
+      t.column :uuid, :uuid, default: "gen_random_uuid()"
+    end
+  end
+
+  def down
+    change_table :users do |t|
+      t.column :uuid, :uuid, default: nil
+    end
+  end
+end
+
+class ChangeColumnDefaultWithChangeTableAndChangeDefault < TestMigration
+  def up
+    change_table :users do |t|
+      t.change_default :uuid, "gen_random_uuid()"
+    end
+  end
+
+  def down
+    change_table :users do |t|
+      t.change_default :uuid, nil
+    end
+  end
+end
+
+class ChangeColumnDefaultWithChangeTableAndChangeDefaultFromTo < TestMigration
+  def change
+    change_table :users do |t|
+      t.change_default :uuid, from: nil, to: "gen_random_uuid()"
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,6 +31,7 @@ ActiveRecord::SchemaMigration.create_table
 
 ActiveRecord::Schema.define do
   enable_extension "citext" if $adapter == "postgresql"
+  enable_extension "pgcrypto" if $adapter == "postgresql"
 
   [:users, :new_users, :orders, :devices, :cities_users].each do |table|
     drop_table(table) if table_exists?(table)
@@ -46,6 +47,7 @@ ActiveRecord::Schema.define do
     t.text :description
     t.citext :code if $adapter == "postgresql"
     t.references :order
+    t.uuid :uuid
   end
 
   create_table :orders do |t|


### PR DESCRIPTION
Recently we've had an issue with adding a uuid column with a default to fill it up during migration. Which resulted in DB being locked during migration because apparently if you use a function for a default value of a column it evaluates this function during the migration for each existing row. This check can help to prevent locking the DB in such cases