### PR TITLE
Improve error message on `add_column ..., default: nil`

### DIFF
--- a/lib/strong_migrations/checks.rb
+++ b/lib/strong_migrations/checks.rb
@@ -44,14 +44,21 @@ module StrongMigrations
 Then add the NOT NULL constraint in separate migrations."
         end
 
-        raise_error :add_column_default,
-          add_command: command_str("add_column", [table, column, type, options.except(:default)]),
-          change_command: command_str("change_column_default", [table, column, default]),
-          remove_command: command_str("remove_column", [table, column]),
-          code: backfill_code(table, column, default, volatile),
-          append: append,
-          rewrite_blocks: adapter.rewrite_blocks,
-          default_type: (volatile ? "volatile" : "non-null")
+        if default.nil?
+          raise_error :add_column_default_null,
+            command: command_str("add_column", [table, column, type, options.except(:default)]),
+            append: append,
+            rewrite_blocks: adapter.rewrite_blocks
+        else
+          raise_error :add_column_default,
+            add_command: command_str("add_column", [table, column, type, options.except(:default)]),
+            change_command: command_str("change_column_default", [table, column, default]),
+            remove_command: command_str("remove_column", [table, column]),
+            code: backfill_code(table, column, default, volatile),
+            append: append,
+            rewrite_blocks: adapter.rewrite_blocks,
+            default_type: (volatile ? "volatile" : "non-null")
+        end
       elsif default.is_a?(Proc) && postgresql?
         # adding a column with a VOLATILE default is not safe
         # https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-NOTES

--- a/lib/strong_migrations/error_messages.rb
+++ b/lib/strong_migrations/error_messages.rb
@@ -25,6 +25,16 @@ class Backfill%{migration_name} < ActiveRecord::Migration%{migration_suffix}
   end
 end",
 
+    add_column_default_null:
+"Adding a column with a null default blocks %{rewrite_blocks} while the entire table is rewritten.
+Instead, add the column without a default value, then change the default.
+
+class %{migration_name} < ActiveRecord::Migration%{migration_suffix}
+  def change
+    %{command}
+  end
+end",
+
     add_column_default_callable:
 "Strong Migrations does not support inspecting callable default values.
 Please make really sure you're not calling a VOLATILE function,


### PR DESCRIPTION
# Problem

This gem raises an error for an explicit null default value since https://github.com/ankane/strong_migrations/issues/199.
The error message is the same as the non-null's one. But there are differences between null and non-null messages.

* The message for non-null says, `Adding a column with a **non-null** default blocks writes while the entire table is rewritten`. It is not appropriate for null default.
* The message displays `change_column_default :table, :column, nil`. It is unnecessary for null default.
* This message displays how to backfill. It is unnecessary too.

# Solution

Update the error message for null default. There are many differences, so I defined a new key for the message.


# Testing

I'm not sure how to test this change. I couldn't find any tests to assert error messages, so I didn't add a test case for this change.



By the way, I just confirmed the behavior with a test script, which is based on https://github.com/rails/rails/blob/de771c979eca99e37e975a58618dd254fc472986/guides/bug_report_templates/active_record_migrations_gem.rb.

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # Activate the gem you are reporting the issue against.
  gem "activerecord", "~> 7.0.0"
  gem 'strong_migrations', path: '.'
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

ActiveRecord::Schema.define do
  create_table :payments, force: true do |t|
    t.decimal :amount, precision: 10, scale: 0, default: 0, null: false
  end
end

class Payment < ActiveRecord::Base
end

class AddTitleToPayment < ActiveRecord::Migration[7.0]
  def change
    add_column :payments, :title, :string, default: nil
  end
end

class BugTest < Minitest::Test
  def test_migration
    AddTitleToPayment.migrate(:up)
  end
end
```


### before (c8091216e494560d7289ab0c76b330b646923565)

```
  1) Error:
BugTest#test_migration:
StrongMigrations::UnsafeMigration: 
=== Dangerous operation detected #strong_migrations ===

Adding a column with a non-null default blocks reads and writes while the entire table is rewritten.
Instead, add the column without a default value, then change the default.

class AddTitleToPayment < ActiveRecord::Migration[7.0]
  def up
    add_column :payments, :title, :string
    change_column_default :payments, :title, nil
  end

  def down
    remove_column :payments, :title
  end
end

Then backfill the existing rows in the Rails console or a separate migration with disable_ddl_transaction!.

class BackfillAddTitleToPayment < ActiveRecord::Migration[7.0]
  disable_ddl_transaction!

  def up
    Payment.unscoped.in_batches do |relation| 
      relation.update_all title: nil
      sleep(0.01)
    end
  end
end
```


### after

```
  1) Error:
BugTest#test_migration:
StrongMigrations::UnsafeMigration: 
=== Dangerous operation detected #strong_migrations ===

Adding a column with a null default blocks reads and writes while the entire table is rewritten.
Instead, add the column without a default value, then change the default.

class AddTitleToPayment < ActiveRecord::Migration[7.0]
  def change
    add_column :payments, :title, :string
  end
end
```