### PR TITLE
Note that increasing column limit is safe only in MariaDB 10.5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Type | Safe Changes
 `time` | Increasing or removing `:precision`
 `timestamptz` | Increasing or removing `:limit`, changing to `datetime` when session time zone is UTC in Postgres 12+
 
-And some in MySQL and MariaDB:
+And some in MySQL and MariaDB 10.5+:
 
 Type | Safe Changes
 --- | ---


### PR DESCRIPTION
At work we're currently running MariaDB 10.4, which unfortunately takes a write lock while it's increasing the column limit. Starting from MariaDB 10.5, the schema change is instantaneous regardless of the table size. I verified that *reducing* the limit still take very long (as it probably does a table rewrite), as expected.
