### PR TITLE
Add add_column with index check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+- Added check for `add_column_with_index`
+
 ## 1.4.3 (2023-02-19)
 
 - Fixed check for `change_column` to account for charset with MySQL and MariaDB

--- a/README.md
+++ b/README.md
@@ -157,6 +157,38 @@ end
 
 See the next section for how to backfill.
 
+### Adding a column with an index
+
+#### Bad
+
+When adding a column with an index, two internal operations are performed: adding the column and adding the index. The first is safe, but the second is not.
+
+```ruby
+class AddSomeIndexedColumnToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :some_column, :text, index: true
+  end
+end
+```
+
+#### Good
+
+Instead, add the column without an index, then add the index in a separate migration, using concurrent index creation.
+
+```ruby
+class AddSomeIndexedColumnToUsers < ActiveRecord::Migration[7.0]
+  def up
+    add_column :users, :some_column, :text
+  end
+
+  def down
+    remove_column :users, :some_column
+  end
+end
+```
+
+See the the section lower down on [adding an index concurrently](#adding-an-index-non-concurrently).
+
 ### Backfilling data
 
 #### Bad

--- a/lib/strong_migrations/checks.rb
+++ b/lib/strong_migrations/checks.rb
@@ -71,6 +71,10 @@ Then add the NOT NULL constraint in separate migrations."
         raise_error :add_column_json,
           command: command_str("add_column", [table, column, :jsonb, options])
       end
+
+      if options.key?(:index).present? && options.fetch(:index) != false
+        raise_error :add_column_with_index
+      end
     end
 
     def check_add_exclusion_constraint(*args)

--- a/lib/strong_migrations/error_messages.rb
+++ b/lib/strong_migrations/error_messages.rb
@@ -234,7 +234,11 @@ end",
 Use disable_ddl_transaction! or a separate migration.",
 
     add_exclusion_constraint:
-"Adding an exclusion constraint blocks reads and writes while every row is checked."
+"Adding an exclusion constraint blocks reads and writes while every row is checked.",
+
+    add_column_with_index:
+"Adding a column with an index blocks writes. Instead, add the column without an index, then
+add the index concurrently in a separate migration."
   }
   self.enabled_checks = (error_messages.keys - [:remove_index]).map { |k| [k, {}] }.to_h
 end

--- a/test/add_column_test.rb
+++ b/test/add_column_test.rb
@@ -57,4 +57,12 @@ class AddColumnTest < Minitest::Test
     skip unless postgresql?
     assert_unsafe AddColumnJson
   end
+
+  def test_with_index
+    assert_unsafe AddColumnWithIndex
+  end
+
+  def test_with_unique_index
+    assert_unsafe AddColumnWithUniqueIndex
+  end
 end

--- a/test/migrations/add_column.rb
+++ b/test/migrations/add_column.rb
@@ -40,3 +40,15 @@ class AddColumnJson < TestMigration
     add_column :users, :properties, :json
   end
 end
+
+class AddColumnWithIndex < TestMigration
+  def change
+    add_column :users, :nice, :string, index: true
+  end
+end
+
+class AddColumnWithUniqueIndex < TestMigration
+  def change
+    add_column :users, :nice, :string, index: :unique
+  end
+end


### PR DESCRIPTION
When ActiveRecord adds a column with an index, it adds the column (safe) then adds the index concurrently. This locks the table, and is unsafe.

This PR adds a check for adding columns with an index.