### PR TITLE
Catch unsafe migration when increasing limit on indexed string column

### DIFF
--- a/lib/strong_migrations/adapters/postgresql_adapter.rb
+++ b/lib/strong_migrations/adapters/postgresql_adapter.rb
@@ -54,7 +54,7 @@ module StrongMigrations
           # not safe to decrease limit or add a limit
           case existing_type
           when "character varying"
-            safe = !options[:limit] || (existing_column.limit && options[:limit] >= existing_column.limit)
+            safe = !options[:limit] || (existing_column.limit && options[:limit] >= existing_column.limit && !indexed?(table, column))
           when "text"
             safe = !options[:limit]
           when "citext"

--- a/test/change_column_test.rb
+++ b/test/change_column_test.rb
@@ -19,6 +19,10 @@ class ChangeColumnTest < Minitest::Test
     assert_safe ChangeColumnVarcharIncreaseLimit
   end
 
+  def test_varchar_increase_limit_indexed
+    assert_unsafe ChangeColumnVarcharIncreaseLimitIndexed
+  end
+
   def test_varchar_increase_limit_over_64
     if postgresql?
       assert_safe ChangeColumnVarcharIncreaseLimit64

--- a/test/migrations/change_column.rb
+++ b/test/migrations/change_column.rb
@@ -34,6 +34,18 @@ class ChangeColumnVarcharIncreaseLimit < TestMigration
   end
 end
 
+class ChangeColumnVarcharIncreaseLimitIndexed < TestMigration
+  def up
+    safety_assured { add_index :users, :country }
+    change_column :users, :country, :string, limit: 21
+  end
+
+  def down
+    change_column :users, :country, :string, limit: 20
+    remove_index :users, :country
+  end
+end
+
 class ChangeColumnVarcharIncreaseLimit64 < TestMigration
   def up
     change_column :users, :country, :string, limit: 64


### PR DESCRIPTION
We ran into an issue where the [documentation calls out ](https://github.com/ankane/strong_migrations#changing-the-type-of-a-column)changing a string limit is not safe if indexed but the code does not check if column is indexed.

> Increasing or removing :limit, changing to text, changing citext if not indexed

We had ran into this issue while running the migration on postgres and it locking the table. We have verified this change would have caught the issue.

The error message doesn't mention anything about index. Let me know if we should change error message.
```
bundle exec rails db:migrate:up VERSION=20230227184754
== 20230227184754 StagingTest: migrating ======================================
rails aborted!
StandardError: An error has occurred, all later migrations canceled:
=== Dangerous operation detected #strong_migrations ===
Changing the type of an existing column blocks reads and writes
while the entire table is rewritten. A safer approach is to:
1. Create a new column
2. Write to both columns
3. Backfill data from the old column to the new column
4. Move reads from the old column to the new column
5. Stop writing to the old column
6. Drop the old column
/Users/user_name/projects/project_name/db/migrate/20230227184754_staging_test.rb:12:in `up'
Caused by:
StrongMigrations::UnsafeMigration:
=== Dangerous operation detected #strong_migrations ===
Changing the type of an existing column blocks reads and writes
while the entire table is rewritten. A safer approach is to:
1. Create a new column
2. Write to both columns
3. Backfill data from the old column to the new column
4. Move reads from the old column to the new column
5. Stop writing to the old column
6. Drop the old column
/Users/user_name/projects/project_name/db/migrate/20230227184754_staging_test.rb:12:in `up'
Tasks: TOP => db:migrate:up
(See full trace by running task with --trace)
```