### PR TITLE
Clarify use of `unscoped` when backfilling

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ class BackfillSomeColumn < ActiveRecord::Migration[7.0]
   end
 end
 ```
+Note: When introducing new columns to models with a default_scope (e.g., with soft deletion), employ `unscoped` to backfill and update all rows comprehensively. This guards against potential problems when executing unscoped queries without the default column being appropriately set.
 
 ### Adding a stored generated column
 


### PR DESCRIPTION
The use of `unscoped` for backfilling was introduced in https://github.com/ankane/strong_migrations/pull/77, which I think was really nice! However, there's no explanation for it in the main README. This PR introduces that so everyone knows why the `unscoped` is a good thing to keep in mind there.

Open to feedback, of course! LMK what you think! Thanks.