### PR TITLE
Add foreign key options to safe_add_reference

### DIFF
--- a/lib/strong_migrations/safe_methods.rb
+++ b/lib/strong_migrations/safe_methods.rb
@@ -29,11 +29,12 @@ module StrongMigrations
               else
                 (ActiveRecord::Base.pluralize_table_names ? reference.to_s.pluralize : reference).to_sym
               end
-
+            
+            foreign_key_opts = foreign_key.is_a?(Hash) ? foreign_key.except(:to_table) : {}
             if reference
-              @migration.add_foreign_key(table, name, column: "#{reference}_id")
+              @migration.add_foreign_key(table, name, column: "#{reference}_id", **foreign_key_opts)
             else
-              @migration.add_foreign_key(table, name)
+              @migration.add_foreign_key(table, name, **foreign_key_opts)
             end
           end
         end

--- a/test/migrations/add_reference.rb
+++ b/test/migrations/add_reference.rb
@@ -34,6 +34,12 @@ class AddReferenceForeignKeyToTable < TestMigration
   end
 end
 
+class AddReferenceForeignKeyOnDelete < TestMigration
+  def change
+    add_reference :users, :device, foreign_key: {on_delete: :nullify}, index: false
+  end
+end
+
 class AddReferenceConcurrently < TestMigration
   disable_ddl_transaction!
 

--- a/test/safe_by_default_test.rb
+++ b/test/safe_by_default_test.rb
@@ -66,6 +66,10 @@ class SafeByDefaultTest < Minitest::Test
     assert_safe AddReferenceForeignKeyToTable
   end
 
+  def test_add_reference_foreign_key_on_delete
+    assert_safe AddReferenceForeignKeyOnDelete
+  end
+
   def test_add_reference_extra_arguments
     assert_argument_error AddReferenceExtraArguments
   end


### PR DESCRIPTION
This will handle for example `foreign_key: { to_table: :table_name, on_delete: :nullify }`