### PR TITLE
feat: Add action and start_after to custom checks

### DIFF
--- a/test/migrations/misc.rb
+++ b/test/migrations/misc.rb
@@ -41,3 +41,21 @@ class Custom < TestMigration
     add_column :users, :forbidden, :string
   end
 end
+
+class CustomAction < TestMigration
+  disable_ddl_transaction!
+
+  def change
+    add_index :devices, :forbidden, algorithm: :concurrently
+  end
+end
+
+class CustomVersion < TestMigration
+  def change
+    add_column :orders, :forbidden, :string
+  end
+
+  def version
+    20170101000000
+  end
+end

--- a/test/misc_test.rb
+++ b/test/misc_test.rb
@@ -29,6 +29,14 @@ class MiscTest < Minitest::Test
     assert_unsafe Custom, "Cannot add forbidden column"
   end
 
+  def test_custom_action
+    assert_safe CustomAction
+  end
+
+  def test_custom_version
+    assert_safe CustomVersion
+  end
+
   def test_unsupported_version
     error = assert_raises(StrongMigrations::UnsupportedVersion) do
       with_target_version(1) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :devices do |t|
+    t.string :forbidden
   end
 end
 
@@ -109,7 +110,7 @@ class Minitest::Test
       schema_migration.delete_all
     end
     migration = migration.new unless migration.is_a?(TestMigration)
-    migration.version ||= 123
+    migration.version ||= 20170101000001
     if direction == :down
       if ActiveRecord::VERSION::STRING.to_f >= 7.1
         schema_migration.create_version(migration.version)
@@ -179,8 +180,8 @@ class Minitest::Test
   end
 end
 
-StrongMigrations.add_check do |method, args|
-  if method == :add_column && args[1].to_s == "forbidden"
+StrongMigrations.add_check(:add_column, start_after: 20170101000000) do |method, args|
+  if args[1].to_s == "forbidden"
     stop! "Cannot add forbidden column"
   end
 end


### PR DESCRIPTION
Hey!

Firstly, thank you verymuch for all the work with strong migrations, great work!

Recently we have added few custom checks.  We had to use `enable_check` and `check_enabled?` methods with custom check names so we are able to enable them only after given migration version. I believe that could be part of StrongMigrations, what do you think?
