### PR TITLE
Drop invalid index in safe_add_index

### DIFF
--- a/lib/strong_migrations/adapters/postgresql_adapter.rb
+++ b/lib/strong_migrations/adapters/postgresql_adapter.rb
@@ -169,6 +169,22 @@ module StrongMigrations
         rows.empty? || rows.any? { |r| r["provolatile"] == "v" }
       end
 
+      def invalid_index?(index_name)
+        query = <<~SQL
+          SELECT
+            pg_class.relname
+          FROM
+            pg_class
+          INNER JOIN
+            pg_index ON pg_index.indexrelid = pg_class.oid
+          WHERE
+            pg_index.indisvalid = false AND
+            pg_class.relname = #{connection.quote(index_name)}
+        SQL
+
+        select_all(query.squish).any?
+      end
+
       private
 
       def set_timeout(setting, timeout)

--- a/lib/strong_migrations/safe_methods.rb
+++ b/lib/strong_migrations/safe_methods.rb
@@ -7,7 +7,7 @@ module StrongMigrations
     def safe_add_index(table, columns, **options)
       index_name = options.fetch(:name, connection.index_name(table, columns))
       if postgresql? && adapter.invalid_index?(index_name)
-        safe_remove_index(table, columns, **options)
+        safe_remove_index(table, name: index_name)
       end
 
       disable_transaction

--- a/test/migrations/add_index.rb
+++ b/test/migrations/add_index.rb
@@ -59,6 +59,12 @@ class AddIndexColumnsUnique < TestMigration
   end
 end
 
+class SafeAddIndexColumnsUnique < TestMigration
+  def change
+    add_index :users, :name, unique: true
+  end
+end
+
 class AddIndexName < TestMigration
   def change
     add_index :users, :name, name: "my_index"

--- a/test/safe_by_default_test.rb
+++ b/test/safe_by_default_test.rb
@@ -152,4 +152,21 @@ class SafeByDefaultTest < Minitest::Test
   ensure
     User.delete_all
   end
+
+  def test_add_index_with_invalid_present
+    skip unless postgresql?
+
+    User.create(name: 'same')
+    duplicate = User.create(name: 'same')
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      migrate SafeAddIndexColumnsUnique
+    end
+
+    duplicate.delete
+
+    assert_safe SafeAddIndexColumnsUnique
+  ensure
+    User.delete_all
+  end
 end


### PR DESCRIPTION
Hi! Saw this TODO in the code, we've been running something similar in our codebase, so better contribute it back :) 

Allow `safe_add_index` to be seamlessly retried.

When the `add_index...concurrently` fails, the index is left in Postgres with `INVALID` status.

The new code drops the index if it's found and invalid. With this, if the migration fails because of a lock timeout for example, on retry it can work. Without it the retries always fail until you manually drop the index.
