### PR TITLE
Add changelog uri in metadata

### DIFF
--- a/strong_migrations.gemspec
+++ b/strong_migrations.gemspec
@@ -10,6 +10,10 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Andrew Kane", "Bob Remeika", "David Waller"]
   spec.email         = ["andrew@ankane.org", "bob.remeika@gmail.com"]
 
+  s.metadata         = {
+    "changelog_uri" => "https://github.com/ankane/strong_migrations/blob/master/CHANGELOG.md"
+  }
+
   spec.files         = Dir["*.{md,txt}", "{lib}/**/*"]
   spec.require_path  = "lib"
 


### PR DESCRIPTION
Rubygems allows to specify [metadata](https://guides.rubygems.org/specification-reference/#metadata).

This patch adds the `changelog_uri` to help others find where the CHANGELOG is.