### PR TITLE
Use calling migration version for `safe_version?` when calling `revert`

### DIFF
--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -123,6 +123,10 @@ module StrongMigrations
       end
     end
 
+    def version_safe?
+      version && version <= StrongMigrations.start_after
+    end
+
     private
 
     def check_version_supported
@@ -164,10 +168,6 @@ module StrongMigrations
 
     def safe?
       self.class.safe || ENV["SAFETY_ASSURED"] || (direction == :down && !StrongMigrations.check_down) || version_safe?
-    end
-
-    def version_safe?
-      version && version <= StrongMigrations.start_after
     end
 
     def version

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -20,6 +20,14 @@ module StrongMigrations
     end
     ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
+    def revert(*migration_classes, &block)
+      if strong_migrations_checker.version_safe?
+        safety_assured { super(*migration_classes, &block) }
+      else
+        super(*migration_classes, &block)
+      end
+    end
+
     def safety_assured
       strong_migrations_checker.class.safety_assured do
         yield

--- a/test/migrations/start_after.rb
+++ b/test/migrations/start_after.rb
@@ -7,3 +7,31 @@ class Version < TestMigration
     20170101000001
   end
 end
+
+class AddTableDangerously < TestMigration
+  def change
+    create_table :dangerous_table, force: true do |t|
+    end
+  end
+end
+
+class AddTableDangerouslySafetyAssured < TestMigration
+  def change
+    safety_assured do
+      create_table :dangerous_table, force: true do |t|
+      end
+    end
+  end
+end
+
+class RevertAddTableDangerously < TestMigration
+  def change
+    revert AddTableDangerously
+  end
+end
+
+class RevertAddTableDangerouslySafetyAssured < TestMigration
+  def change
+    safety_assured { revert AddTableDangerously }
+  end
+end

--- a/test/start_after_test.rb
+++ b/test/start_after_test.rb
@@ -13,6 +13,22 @@ class StartAfterTest < Minitest::Test
     end
   end
 
+  def test_revert_before_start_after_safe
+    with_start_after(20170101000000) do
+      migrate AddTableDangerously
+      assert_safe RevertAddTableDangerously
+      migrate RevertAddTableDangerouslySafetyAssured
+    end
+  end
+
+  def test_revert_before_start_after_unsafe
+    with_start_after(1) do
+      migrate AddTableDangerouslySafetyAssured
+      assert_unsafe RevertAddTableDangerously
+      migrate RevertAddTableDangerouslySafetyAssured
+    end
+  end
+
   def with_start_after(start_after)
     StrongMigrations.stub(:start_after, start_after) do
       yield


### PR DESCRIPTION
# The Problem

Let's suppose you initialize your StrongMigrations like so

```rb
# config/initializers/strong_migrations.rb
StrongMigrations.start_after = 20230101000000
```

But, let's say you have a pair of migrations that StrongMigrations would consider "dangerous" from a long time ago that look like this

```rb
# db/migrate/20210101000000_dangerous_migration.rb
class DangerousMigration < ActiveRecord::Migration[7.1]
  def change
    # ... some dangerous operation
  end
end
```

```rb
# db/migrate/20210101000001_revert_dangerous_migration.rb
class RevertDangerousMigration < ActiveRecord::Migration[7.1]
  def change
    revert DangerousMigration
  end
end
```
Under these circumstances, StrongMigrations will fail on the RevertDangerousMigration, even though I would expect it to pass without error since both of these migrations occur before the configured start_after.

My debugging leads me to believe that this is because, when we call revert DangerousMigration, the underlying dangerous operation call on the migration being reverted triggers the [method_missing](https://github.com/ankane/strong_migrations/blob/4e928b5ba5519f92a84fbe7b1b439dfd24d6aa60/lib/strong_migrations/migration.rb#L9-L20) logic that ultimately checks the safety of the migration being reverted, but StrongMigration has no context of this migration's version since the migration is called as a class with no context for the original filename. In other words, StrongMigrations doesn't have knowledge of the version of the migration being reverted, only that of the migration doing the revert. When StrongMigrations doesn't see a version, it assumes the migration is unsafe, causing it to fail.

## The Solution

I had the thought to override the revert method and check the migration's version there before moving onto the child migration. I'm open to other ideas about how best to solve this.

Ultimately, these changes make it so that, in a migration where you call the `revert` method, StrongMigrations compares the calling migration's version against `StrongMigration.start_after` to decide whether or not to run checks on the reverted migration.

Because of the details of the way the tests are set up, the reason why these tests would fail before the changes aren't obvious at first, so let me explain.

In the failing test, the first migration `AddTableDangerously` is given the default migration version `123` that is defined [here](https://github.com/ankane/strong_migrations/blob/master/test/test_helper.rb#L118).

When we call `assert_safe RevertAddTableDangerously` in the test, we only end up calling the helper `migrate` function on the `RevertAddTableDangerously` migration. When this migration then calls the `change` method on the migration it is reverting, `AddTableDangerously`, we don't give it the default `123` version, leaving it as `nil`, which then fails the `version_safe?` method [here](https://github.com/ankane/strong_migrations/blob/master/lib/strong_migrations/checker.rb#L169).

This is not identical to my tests with the gem in a dummy live app, but it's identical in that the child migration that is being reverted also has a `nil` version when running with the dummy app, causing it to fail before the changes are implemented.

Now, with the changes, we implement a `def revert` method that checks the version, then passes everything on to `super` with a `safety_assured` block if the calling migration's version is safe.

I looked to [`active_record/migration.rb#revert`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/migration.rb#L843) for the method signature that I needed to override and then pass onto `super`.
