### PR TITLE
Add missing "the" in README.md [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ A safer approach is to:
 
 1. Create a new table
 2. Write to both tables
-3. Backfill data from the old table to new table
+3. Backfill data from the old table to the new table
 4. Move reads from the old table to the new table
 5. Stop writing to the old table
 6. Drop the old table


### PR DESCRIPTION
In the "Renaming a table" section.