### PR TITLE
Disabled databases will still run the migration

### DIFF
--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -28,7 +28,8 @@ module StrongMigrations
     end
 
     def perform(method, *args)
-      return if !enabled?
+      # yield will execute migration, but stops the checks
+      return yield unless enabled?
       check_adapter
       check_version_supported
       set_timeouts


### PR DESCRIPTION
Following up on this Issue: https://github.com/ankane/strong_migrations/issues/255