### PR TITLE
Add custom checks for TableDefinitions

### DIFF
--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -26,7 +26,7 @@ module StrongMigrations
   class UnsupportedVersion < Error; end
 
   class << self
-    attr_accessor :auto_analyze, :start_after, :checks, :error_messages,
+    attr_accessor :auto_analyze, :start_after, :checks, :table_checks, :error_messages,
                   :target_postgresql_version, :target_mysql_version, :target_mariadb_version,
                   :enabled_checks, :lock_timeout, :statement_timeout, :check_down, :target_version,
                   :safe_by_default, :target_sql_mode, :lock_timeout_retries, :lock_timeout_retry_delay,
@@ -38,6 +38,7 @@ module StrongMigrations
   self.lock_timeout_retries = 0
   self.lock_timeout_retry_delay = 10 # seconds
   self.checks = []
+  self.table_checks = []
   self.safe_by_default = false
   self.check_down = false
   self.alphabetize_schema = false
@@ -62,6 +63,10 @@ module StrongMigrations
       @lock_timeout_limit = developer_env? ? false : 10
     end
     @lock_timeout_limit
+  end
+
+  def self.add_table_check(&block)
+    table_checks << block
   end
 
   def self.add_check(&block)
@@ -92,7 +97,6 @@ require_relative 'strong_migrations/error_messages'
 ActiveSupport.on_load(:active_record) do
   ActiveRecord::Migration.prepend(StrongMigrations::Migration)
   ActiveRecord::Migrator.prepend(StrongMigrations::Migrator)
-  # ActiveRecord::ConnectionAdapters::TableDefinition.prepend(StrongMigrations::TableDefinition)
 
   if defined?(ActiveRecord::Tasks::DatabaseTasks)
     ActiveRecord::Tasks::DatabaseTasks.singleton_class.prepend(StrongMigrations::DatabaseTasks)

--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -1,23 +1,24 @@
 # dependencies
-require "active_support"
+require 'active_support'
 
 # adapters
-require_relative "strong_migrations/adapters/abstract_adapter"
-require_relative "strong_migrations/adapters/mysql_adapter"
-require_relative "strong_migrations/adapters/mariadb_adapter"
-require_relative "strong_migrations/adapters/postgresql_adapter"
+require_relative 'strong_migrations/adapters/abstract_adapter'
+require_relative 'strong_migrations/adapters/mysql_adapter'
+require_relative 'strong_migrations/adapters/mariadb_adapter'
+require_relative 'strong_migrations/adapters/postgresql_adapter'
 
 # modules
-require_relative "strong_migrations/checks"
-require_relative "strong_migrations/safe_methods"
-require_relative "strong_migrations/checker"
-require_relative "strong_migrations/database_tasks"
-require_relative "strong_migrations/migration"
-require_relative "strong_migrations/migrator"
-require_relative "strong_migrations/version"
+require_relative 'strong_migrations/checks'
+require_relative 'strong_migrations/safe_methods'
+require_relative 'strong_migrations/checker'
+require_relative 'strong_migrations/database_tasks'
+require_relative 'strong_migrations/migration'
+require_relative 'strong_migrations/migrator'
+require_relative 'strong_migrations/version'
+require_relative 'strong_migrations/table_definition'
 
 # integrations
-require_relative "strong_migrations/railtie" if defined?(Rails)
+require_relative 'strong_migrations/railtie' if defined?(Rails)
 
 module StrongMigrations
   class Error < StandardError; end
@@ -26,10 +27,10 @@ module StrongMigrations
 
   class << self
     attr_accessor :auto_analyze, :start_after, :checks, :error_messages,
-      :target_postgresql_version, :target_mysql_version, :target_mariadb_version,
-      :enabled_checks, :lock_timeout, :statement_timeout, :check_down, :target_version,
-      :safe_by_default, :target_sql_mode, :lock_timeout_retries, :lock_timeout_retry_delay,
-      :alphabetize_schema
+                  :target_postgresql_version, :target_mysql_version, :target_mariadb_version,
+                  :enabled_checks, :lock_timeout, :statement_timeout, :check_down, :target_version,
+                  :safe_by_default, :target_sql_mode, :lock_timeout_retries, :lock_timeout_retry_delay,
+                  :alphabetize_schema
     attr_writer :lock_timeout_limit
   end
   self.auto_analyze = false
@@ -43,7 +44,7 @@ module StrongMigrations
 
   # private
   def self.developer_env?
-    env == "development" || env == "test"
+    env == 'development' || env == 'test'
   end
 
   # private
@@ -52,7 +53,7 @@ module StrongMigrations
       Rails.env
     else
       # default to production for safety
-      ENV["RACK_ENV"] || "production"
+      ENV['RACK_ENV'] || 'production'
     end
   end
 
@@ -68,7 +69,7 @@ module StrongMigrations
   end
 
   def self.enable_check(check, start_after: nil)
-    enabled_checks[check] = {start_after: start_after}
+    enabled_checks[check] = { start_after: start_after }
   end
 
   def self.disable_check(check)
@@ -86,16 +87,17 @@ module StrongMigrations
 end
 
 # load error messages
-require_relative "strong_migrations/error_messages"
+require_relative 'strong_migrations/error_messages'
 
 ActiveSupport.on_load(:active_record) do
   ActiveRecord::Migration.prepend(StrongMigrations::Migration)
   ActiveRecord::Migrator.prepend(StrongMigrations::Migrator)
+  # ActiveRecord::ConnectionAdapters::TableDefinition.prepend(StrongMigrations::TableDefinition)
 
   if defined?(ActiveRecord::Tasks::DatabaseTasks)
     ActiveRecord::Tasks::DatabaseTasks.singleton_class.prepend(StrongMigrations::DatabaseTasks)
   end
 
-  require_relative "strong_migrations/schema_dumper"
+  require_relative 'strong_migrations/schema_dumper'
   ActiveRecord::SchemaDumper.prepend(StrongMigrations::SchemaDumper)
 end

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -28,13 +28,22 @@ module StrongMigrations
       end
     end
 
-    def safety_assured
-      strong_migrations_checker.class.safety_assured do
-        yield
+    def create_table(table_name, **options, &block)
+      if block_given?
+        super do |t|
+          table_definition = StrongMigrations::TableDefinition.new(compatible_table_definition(t))
+          yield table_definition
+        end
+      else
+        super
       end
     end
 
-    def stop!(message, header: "Custom check")
+    def safety_assured(&block)
+      strong_migrations_checker.class.safety_assured(&block)
+    end
+
+    def stop!(message, header: 'Custom check')
       raise StrongMigrations::UnsafeMigration, "\n=== #{header} #strong_migrations ===\n\n#{message}\n"
     end
 

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -31,7 +31,8 @@ module StrongMigrations
     def create_table(table_name, **options, &block)
       if block_given?
         super do |t|
-          table_definition = StrongMigrations::TableDefinition.new(compatible_table_definition(t))
+          table_definition = StrongMigrations::TableDefinition.new(compatible_table_definition(t), self,
+                                                                   strong_migrations_checker)
           yield table_definition
         end
       else

--- a/lib/strong_migrations/table_definition.rb
+++ b/lib/strong_migrations/table_definition.rb
@@ -1,0 +1,13 @@
+module StrongMigrations
+  class TableDefinition
+    def initialize(ar_table_definition)
+      @ar_table_definition = ar_table_definition
+    end
+
+    def method_missing(method, *args, **kwargs)
+      p "StrongMigrations::TableDefinition method_missing called with method: #{method} and args: #{args} and kwargs: #{kwargs}"
+
+      @ar_table_definition.send(method, *args, **kwargs)
+    end
+  end
+end

--- a/lib/strong_migrations/table_definition.rb
+++ b/lib/strong_migrations/table_definition.rb
@@ -1,13 +1,27 @@
 module StrongMigrations
   class TableDefinition
-    def initialize(ar_table_definition)
+    def initialize(ar_table_definition, migration, checker)
       @ar_table_definition = ar_table_definition
+      @migration = migration
+      @checker = checker
     end
 
     def method_missing(method, *args, **kwargs)
-      p "StrongMigrations::TableDefinition method_missing called with method: #{method} and args: #{args} and kwargs: #{kwargs}"
+      return super if is_a?(ActiveRecord::Schema)
 
+      # Active Record 7.0.2+ versioned schema
+      return super if defined?(ActiveRecord::Schema::Definition) && is_a?(ActiveRecord::Schema::Definition)
+
+      unless @checker.safe?
+        StrongMigrations.table_checks.each do |check|
+          @migration.instance_exec(method, args, kwargs, &check)
+        end
+      end
       @ar_table_definition.send(method, *args, **kwargs)
+    end
+
+    def safety_assured(&block)
+      @checker.class.safety_assured(&block)
     end
   end
 end

--- a/test/create_table_test.rb
+++ b/test/create_table_test.rb
@@ -1,0 +1,15 @@
+require_relative 'test_helper'
+
+class CreateTableTest < Minitest::Test
+  def test_create_table_with_integer
+    assert_unsafe CreateTableWithInteger
+  end
+
+  def test_col_definition_in_safe_block
+    assert_safe CreateTableWithSafetyAssured
+  end
+
+  def test_create_table_with_integer_column_call
+    assert_unsafe CreateTableWithIntegerColumnCall
+  end
+end

--- a/test/migrations/create_table.rb
+++ b/test/migrations/create_table.rb
@@ -1,0 +1,35 @@
+class CreateTableWithInteger < TestMigration
+  def up
+    create_table :test_table do |t|
+      t.integer :test_column
+    end
+  end
+
+  def down
+    drop_table :test_table
+  end
+end
+
+class CreateTableWithIntegerColumnCall < TestMigration
+  def up
+    create_table :test_table do |t|
+      t.column :test_column, :integer
+    end
+  end
+
+  def down
+    drop_table :test_table
+  end
+end
+
+class CreateTableWithSafetyAssured < TestMigration
+  def up
+    create_table :test_table do |t|
+      safety_assured { t.integer :test_column }
+    end
+  end
+
+  def down
+    drop_table :test_table
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,36 +1,34 @@
-require "bundler/setup"
+require 'bundler/setup'
 Bundler.require(:default)
-require "minitest/autorun"
-require "minitest/pride"
-require "active_record"
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'active_record'
 
 # needed for target_version
 module Rails
   def self.env
-    ActiveSupport::StringInquirer.new("test")
+    ActiveSupport::StringInquirer.new('test')
   end
 end
 
-$adapter = ENV["ADAPTER"] || "postgresql"
+$adapter = ENV['ADAPTER'] || 'postgresql'
 connection_options = {
   adapter: $adapter,
-  database: "strong_migrations_test"
+  database: 'strong_migrations_test'
 }
-if $adapter == "mysql2"
-  connection_options[:encoding] = "utf8mb4"
-  if ActiveRecord::VERSION::STRING.to_f >= 7.1
-    connection_options[:prepared_statements] = true
-  end
-elsif $adapter == "trilogy"
+if $adapter == 'mysql2'
+  connection_options[:encoding] = 'utf8mb4'
+  connection_options[:prepared_statements] = true if ActiveRecord::VERSION::STRING.to_f >= 7.1
+elsif $adapter == 'trilogy'
   if ActiveRecord::VERSION::STRING.to_f < 7.1
-    require "trilogy_adapter/connection"
-    ActiveRecord::Base.public_send :extend, TrilogyAdapter::Connection
+    require 'trilogy_adapter/connection'
+    ActiveRecord::Base.extend TrilogyAdapter::Connection
   end
-  connection_options[:host] = "127.0.0.1"
+  connection_options[:host] = '127.0.0.1'
 end
 ActiveRecord::Base.establish_connection(**connection_options)
 
-if ENV["VERBOSE"]
+if ENV['VERBOSE']
   ActiveRecord::Base.logger = ActiveSupport::Logger.new($stdout)
 else
   ActiveRecord::Migration.verbose = false
@@ -54,18 +52,18 @@ end
 schema_migration.create_table
 
 ActiveRecord::Schema.define do
-  if $adapter == "postgresql"
+  if $adapter == 'postgresql'
     # for change column
-    enable_extension "citext"
+    enable_extension 'citext'
 
     # for exclusion constraints
-    enable_extension "btree_gist"
+    enable_extension 'btree_gist'
 
     # for gen_random_uuid() in Postgres < 13
-    enable_extension "pgcrypto"
+    enable_extension 'pgcrypto'
   end
 
-  [:users, :new_users, :orders, :devices, :cities_users].each do |table|
+  %i[users new_users orders devices cities_users test_table].each do |table|
     drop_table(table) if table_exists?(table)
   end
 
@@ -77,7 +75,7 @@ ActiveRecord::Schema.define do
     t.string :country, limit: 20
     t.string :interval
     t.text :description
-    t.citext :code if $adapter == "postgresql"
+    t.citext :code if $adapter == 'postgresql'
     t.references :order
   end
 
@@ -93,15 +91,15 @@ end
 
 module Helpers
   def postgresql?
-    $adapter == "postgresql"
+    $adapter == 'postgresql'
   end
 
   def mysql?
-    ($adapter == "mysql2" || $adapter == "trilogy") && !ActiveRecord::Base.connection.mariadb?
+    ($adapter == 'mysql2' || $adapter == 'trilogy') && !ActiveRecord::Base.connection.mariadb?
   end
 
   def mariadb?
-    ($adapter == "mysql2" || $adapter == "trilogy") && ActiveRecord::Base.connection.mariadb?
+    ($adapter == 'mysql2' || $adapter == 'trilogy') && ActiveRecord::Base.connection.mariadb?
   end
 end
 
@@ -133,8 +131,9 @@ class Minitest::Test
       end
     ActiveRecord::Migrator.new(direction, [migration], *args).migrate
     true
-  rescue => e
+  rescue StandardError => e
     raise e.cause if e.cause
+
     raise e
   end
 
@@ -142,7 +141,7 @@ class Minitest::Test
     error = assert_raises(StrongMigrations::UnsafeMigration) do
       migrate(migration, **options)
     end
-    puts error.message if ENV["VERBOSE"]
+    puts error.message if ENV['VERBOSE']
     assert_match message, error.message if message
   end
 
@@ -174,16 +173,12 @@ class Minitest::Test
     StrongMigrations.target_version = nil
   end
 
-  def with_safety_assured
-    StrongMigrations::Checker.stub(:safe, true) do
-      yield
-    end
+  def with_safety_assured(&block)
+    StrongMigrations::Checker.stub(:safe, true, &block)
   end
 
-  def outside_developer_env
-    StrongMigrations.stub(:developer_env?, false) do
-      yield
-    end
+  def outside_developer_env(&block)
+    StrongMigrations.stub(:developer_env?, false, &block)
   end
 
   def check_constraints?
@@ -192,11 +187,17 @@ class Minitest::Test
 end
 
 StrongMigrations.add_check do |method, args|
-  if method == :add_column && args[1].to_s == "forbidden"
-    stop! "Cannot add forbidden column"
+  stop! 'Cannot add forbidden column' if method == :add_column && args[1].to_s == 'forbidden'
+end
+
+StrongMigrations.add_table_check do |method, args, _kwargs|
+  stop!('Use bigint instead to avoid overflow') if method == :integer
+
+  if method == :column && (args[1].to_sym == :integer || args[1].to_sym == :int)
+    stop!('Use bigint instead to avoid overflow')
   end
 end
 
-Dir.glob("migrations/*.rb", base: __dir__).sort.each do |file|
+Dir.glob('migrations/*.rb', base: __dir__).sort.each do |file|
   require_relative file
 end


### PR DESCRIPTION
I took a stab at adding custom checks for TableDefinitions (issue #263). 

Before anyone reviews, @ankane do you mind letting me know what linters you're using on the repo? My VS Code rubocop extension reformatted existing files that I touched which makes parsing the changes difficult.

The key changes are in `lib/strong_migrations/table_definition.rb`, `lib/strong_migrations/migration.rb`.