### PR TITLE
Fix SystemStackError in schema_dumper.rb in combination with activerecord-multi-tenant

### DIFF
--- a/lib/strong_migrations/schema_dumper.rb
+++ b/lib/strong_migrations/schema_dumper.rb
@@ -1,9 +1,16 @@
 module StrongMigrations
   module SchemaDumper
-    def initialize(connection, *args, **options)
-      return super unless StrongMigrations.alphabetize_schema
+    extend ActiveSupport::Concern
 
-      super(WrappedConnection.new(connection), *args, **options)
+    prepended do
+      alias original_initialize initialize
+
+      def initialize(connection, *args, **options)
+
+        return original_initialize(connection, *args, **options) unless StrongMigrations.alphabetize_schema
+
+        original_initialize(WrappedConnection.new(connection), *args, **options)
+      end
     end
   end
 


### PR DESCRIPTION
When using https://github.com/citusdata/activerecord-multi-tenant gem, it also overrides the SchemaDumper. This gem uses alias method instead of `super`.

Reference:
https://github.com/citusdata/activerecord-multi-tenant/blob/0ac43aa98334a29ed3e5b33e0bcc5ee281f97254/lib/activerecord-multi-tenant/migrations.rb#L86

strong_migrations in combination with this gem created following issue:

```
SystemStackError: stack level too deep (SystemStackError)
.../gems/strong_migrations-1.8.0/lib/strong_migrations/schema_dumper.rb:6:in `new'
.../gems/strong_migrations-1.8.0/lib/strong_migrations/schema_dumper.rb:6:in `initialize'
.../gems/activerecord-multi-tenant-2.4.0/lib/activerecord-multi-tenant/migrations.rb:93:in `initialize'
.../gems/strong_migrations-1.8.0/lib/strong_migrations/schema_dumper.rb:6:in `initialize'
.../gems/activerecord-multi-tenant-2.4.0/lib/activerecord-multi-tenant/migrations.rb:93:in `initialize'
.../gems/strong_migrations-1.8.0/lib/strong_migrations/schema_dumper.rb:6:in `initialize'
```

I figured out using the `prepended` with the `alias` method instead avoided the issue in overriding the `initialize` method by multiple gems