### PR TITLE
Fix change_column_null when raising an error in `safe mode`

### DIFF
--- a/lib/strong_migrations/adapters/postgresql_adapter.rb
+++ b/lib/strong_migrations/adapters/postgresql_adapter.rb
@@ -127,7 +127,7 @@ module StrongMigrations
         safe
       end
 
-      def constraints(table_name)
+      def constraints(table_name, include_invalid: false)
         query = <<~SQL
           SELECT
             conname AS name,
@@ -135,8 +135,7 @@ module StrongMigrations
           FROM
             pg_constraint
           WHERE
-            contype = 'c' AND
-            convalidated AND
+            contype = 'c' #{ "AND convalidated" if !include_invalid } AND
             conrelid = #{connection.quote(connection.quote_table_name(table_name))}::regclass
         SQL
         select_all(query.squish).to_a


### PR DESCRIPTION
When changing a column null value from true to false (namely, the column becomes NOT NULL) and `safe mode` is enabled:
-  we add a NOT VALID check constraint
- then commit the transaction
-  and finally validate the check constraint in another migration.

The issue arises when the validation of check constraint fails. This leaves an invalid check constraint in the database and it is NOT dropped in a cleanup phase.
After making sure that all values are NOT NULL), we then retry to run `rails db:migrate`. However this fails, because, since the check constraint already exists, it will result in an error raised stating that said check constraint **already** exists.

This commit fixes the issue in both ways:
- Firstly, if we're already in this unstable state of a NOT VALID check constraint already existing in the database, we avoid the recreation of the constraint and simply ignore this step
- Secondly, in case the check validation fails, we rescue the exception and execute the drop of the check constraint to avoid leaving the database in an unstable state.