### PR TITLE
Fix add_check_constraint  when raising an error in safe mode

### DIFF
--- a/lib/strong_migrations/adapters/postgresql_adapter.rb
+++ b/lib/strong_migrations/adapters/postgresql_adapter.rb
@@ -127,7 +127,7 @@ module StrongMigrations
         safe
       end
 
-      def constraints(table_name)
+      def constraints(table_name, include_invalid: false, constraint_name: nil)
         query = <<~SQL
           SELECT
             conname AS name,
@@ -135,9 +135,9 @@ module StrongMigrations
           FROM
             pg_constraint
           WHERE
-            contype = 'c' AND
-            convalidated AND
+            contype = 'c' #{ "AND convalidated" if !include_invalid } AND
             conrelid = #{connection.quote(connection.quote_table_name(table_name))}::regclass
+            #{" AND conname = '#{constraint_name}'" if constraint_name}
         SQL
         select_all(query.squish).to_a
       end

--- a/test/migrations/add_check_constraint.rb
+++ b/test/migrations/add_check_constraint.rb
@@ -1,6 +1,6 @@
 class AddCheckConstraint < TestMigration
   def change
-    add_check_constraint :users, "credit_score > 0"
+    add_check_constraint :users, "credit_score > 0", name: 'users_credit_score_positive'
   end
 end
 

--- a/test/safe_by_default_test.rb
+++ b/test/safe_by_default_test.rb
@@ -106,6 +106,23 @@ class SafeByDefaultTest < Minitest::Test
     assert_safe AddCheckConstraint
   end
 
+  def test_add_check_constraint_after_failed_attempt
+    skip unless postgresql?
+
+    user = User.create!(credit_score: -1)
+
+    error = assert_raises(ActiveRecord::StatementInvalid) do
+      assert_safe AddCheckConstraint
+    end
+    assert_match  "PG::CheckViolation: ERROR:  check constraint \"users_credit_score_positive\" of relation \"users\" is violated by some row\n", error.message
+
+    user.update!(credit_score: 1)
+
+    assert_safe AddCheckConstraint
+  ensure
+    User.delete_all
+  end
+
   def test_add_check_constraint_extra_arguments
     skip unless postgresql?
 


### PR DESCRIPTION
Followup to https://github.com/ankane/strong_migrations/pull/271

When adding a CHECK constraint and safe mode is enabled:

- we add a NOT VALID check constraint
- then commit the transaction
- and finally validate the check constraint in another migration.

If the validation step fails, this leaves a NOT VALID check constraint in the database.
If we retry after having cleaned up the database, the creation of the NOT VALID check constraint will fail because it will already be in the DB.

This commit makes the migration safely retriable by checking if said check constraint already exists, and if so, skips its creation again.