### PR TITLE
Fixed check_add_column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.idea
+

--- a/lib/strong_migrations/checks.rb
+++ b/lib/strong_migrations/checks.rb
@@ -53,7 +53,7 @@ module StrongMigrations
           append: append,
           rewrite_blocks: adapter.rewrite_blocks,
           default_type: (volatile ? "volatile" : "non-null")
-      elsif default.is_a?(Proc) && postgresql?
+      elsif (default.is_a?(Proc) || default == false) && postgresql?
         # adding a column with a VOLATILE default is not safe
         # https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-NOTES
         # functions like random() and clock_timestamp() are VOLATILE


### PR DESCRIPTION
I tried to add a test boolean field

```ruby
class AddNewFieldToUsers < ActiveRecord::Migration[7.1]
  def change
    add_column :users, :new_field, :boolean, default: false, null: false
  end
end
```

and checker of strong migrations didn't work for my case

PostgreSQL 14.13
Rails 7.1.3.4
ruby 3.3.0

I tried to debug why this happened and came across the fact that `default` ==` false` (default is not Proc)

