### PR TITLE
Fix broken link in README Additional Reading section

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,7 +936,7 @@ You probably don’t need this gem for smaller projects, as operations that are 
 
 - [Zero downtime migrations with ActiveRecord](https://medium.com/klaxit-techblog/zero-downtime-migrations-with-activerecord-47528abe5136/)
 - [PostgreSQL at Scale: Database Schema Changes Without Downtime](https://medium.com/braintree-product-technology/postgresql-at-scale-database-schema-changes-without-downtime-20d3749ed680)
-- [An Overview of DDL Algorithms in MySQL](https://mydbops.wordpress.com/2020/03/04/an-overview-of-ddl-algorithms-in-mysql-covers-mysql-8/)
+- [An Overview of DDL Algorithms in MySQL](https://www.mydbops.com/blog/an-overview-of-ddl-algorithms-in-mysql-covers-mysql-8/)
 - [MariaDB InnoDB Online DDL Overview](https://mariadb.com/kb/en/innodb-online-ddl-overview/)
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ You probably don’t need this gem for smaller projects, as operations that are 
 
 ## Additional Reading
 
-- [Rails Migrations with No Downtime](https://pedro.herokuapp.com/past/2011/7/13/rails_migrations_with_no_downtime/)
+- [Zero downtime migrations with ActiveRecord](https://medium.com/klaxit-techblog/zero-downtime-migrations-with-activerecord-47528abe5136/)
 - [PostgreSQL at Scale: Database Schema Changes Without Downtime](https://medium.com/braintree-product-technology/postgresql-at-scale-database-schema-changes-without-downtime-20d3749ed680)
 - [An Overview of DDL Algorithms in MySQL](https://mydbops.wordpress.com/2020/03/04/an-overview-of-ddl-algorithms-in-mysql-covers-mysql-8/)
 - [MariaDB InnoDB Online DDL Overview](https://mariadb.com/kb/en/innodb-online-ddl-overview/)


### PR DESCRIPTION
Some links to related articles in the Additional Reading section of the README were broken, so I have replaced them with 
 alternatives.

However, I am unable to determine if these replacement articles are appropriate substitutes for the originals. Please review them and merge if there are no issues.