### PR TITLE
Add metadata to gemspec

### DIFF
--- a/strong_migrations.gemspec
+++ b/strong_migrations.gemspec
@@ -16,4 +16,9 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1"
 
   spec.add_dependency "activerecord", ">= 6.1"
+
+  spec.metadata = {
+    "changelog_uri"     => "https://github.com/ankane/strong_migrations/blob/v#{StrongMigrations::VERSION}/CHANGELOG.md",
+    "source_code_uri"   => "https://github.com/ankane/strong_migrations",
+  }
 end


### PR DESCRIPTION
Hello!

Just noticed while browsing rubygems that strong_migrations doesn't have a changelog or source code link in the "links" section for the gem:

![CleanShot 2024-10-20 at 14 21 31@2x](https://github.com/user-attachments/assets/2a9e1972-69d6-4c52-bcb0-25aecd180de6)

From: https://rubygems.org/gems/strong_migrations

If the gemspec provides this [metadata](https://guides.rubygems.org/specification-reference/#metadata), rubygems will add those links.

Personally I find those useful, so I thought I'd open this PR to suggest adding them. WDYT?