### PR TITLE
Disable `safe_by_default` on existing migrations

### DIFF
--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -41,7 +41,7 @@ module StrongMigrations
       set_timeouts
       check_lock_timeout
 
-      if !safe? || safe_by_default_method?(method)
+      if !safe? || safe_by_default_method?(method, version: version)
         # TODO better pattern
         # see checks.rb for methods
         case method

--- a/lib/strong_migrations/safe_methods.rb
+++ b/lib/strong_migrations/safe_methods.rb
@@ -1,7 +1,9 @@
 module StrongMigrations
   module SafeMethods
-    def safe_by_default_method?(method)
-      StrongMigrations.safe_by_default && [:add_index, :add_belongs_to, :add_reference, :remove_index, :add_foreign_key, :add_check_constraint, :change_column_null].include?(method)
+    def safe_by_default_method?(method, version: nil)
+      StrongMigrations.safe_by_default &&
+        StrongMigrations.check_enabled?(method, version: version) &&
+        [:add_index, :add_belongs_to, :add_reference, :remove_index, :add_foreign_key, :add_check_constraint, :change_column_null].include?(method)
     end
 
     def safe_add_index(*args, **options)

--- a/test/safe_by_default_test.rb
+++ b/test/safe_by_default_test.rb
@@ -219,6 +219,14 @@ class SafeByDefaultTest < Minitest::Test
     User.delete_all
   end
 
+  def test_change_column_null_default_with_start_after
+    skip unless postgresql?
+
+    StrongMigrations.stub(:start_after, 20170101000000) do
+      assert_safe ChangeColumnNullDefault
+    end
+  end
+
   def test_change_column_null_invalid
     skip unless postgresql?
 


### PR DESCRIPTION
When `safe_by_default` is enabled, an error occurs in `db:migrate` if
existing migrations has `change_column_null` with a default value.

refs: https://github.com/ankane/strong_migrations/blob/8e9baaa05c35fc9fdf206160c00b309c6e3a8bb6/lib/strong_migrations/safe_methods.rb#L83

To avoid this error, disable `safe_by_default` on existing migrations.
Not required for migrations created before the strong_migrations gem is installed.
