### PR TITLE
support transaction_timeout (introduced in PG17)

### DIFF
--- a/lib/generators/strong_migrations/templates/initializer.rb.tt
+++ b/lib/generators/strong_migrations/templates/initializer.rb.tt
@@ -4,7 +4,6 @@ StrongMigrations.start_after = <%= start_after %>
 # Set timeouts for migrations<%= pgbouncer_message %>
 StrongMigrations.lock_timeout = 10.seconds
 StrongMigrations.statement_timeout = 1.hour
-StrongMigrations.transaction_timeout = 1.hour
 
 # Analyze tables after indexes are added
 # Outdated statistics can sometimes hurt performance

--- a/lib/generators/strong_migrations/templates/initializer.rb.tt
+++ b/lib/generators/strong_migrations/templates/initializer.rb.tt
@@ -4,6 +4,7 @@ StrongMigrations.start_after = <%= start_after %>
 # Set timeouts for migrations<%= pgbouncer_message %>
 StrongMigrations.lock_timeout = 10.seconds
 StrongMigrations.statement_timeout = 1.hour
+StrongMigrations.transaction_timeout = 1.hour
 
 # Analyze tables after indexes are added
 # Outdated statistics can sometimes hurt performance

--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -27,10 +27,9 @@ module StrongMigrations
   class << self
     attr_accessor :auto_analyze, :start_after, :checks, :error_messages,
       :target_postgresql_version, :target_mysql_version, :target_mariadb_version,
-      :enabled_checks, :lock_timeout, :statement_timeout, :transaction_timeout, :check_down,
-      :target_version, :safe_by_default, :target_sql_mode, :lock_timeout_retries,
-      :lock_timeout_retry_delay, :alphabetize_schema, :skipped_databases,
-      :remove_invalid_indexes
+      :enabled_checks, :lock_timeout, :statement_timeout, :check_down, :target_version,
+      :safe_by_default, :target_sql_mode, :lock_timeout_retries, :lock_timeout_retry_delay,
+      :alphabetize_schema, :skipped_databases, :remove_invalid_indexes, :transaction_timeout
     attr_writer :lock_timeout_limit
   end
   self.auto_analyze = false

--- a/lib/strong_migrations.rb
+++ b/lib/strong_migrations.rb
@@ -27,9 +27,10 @@ module StrongMigrations
   class << self
     attr_accessor :auto_analyze, :start_after, :checks, :error_messages,
       :target_postgresql_version, :target_mysql_version, :target_mariadb_version,
-      :enabled_checks, :lock_timeout, :statement_timeout, :check_down, :target_version,
-      :safe_by_default, :target_sql_mode, :lock_timeout_retries, :lock_timeout_retry_delay,
-      :alphabetize_schema, :skipped_databases, :remove_invalid_indexes
+      :enabled_checks, :lock_timeout, :statement_timeout, :transaction_timeout, :check_down,
+      :target_version, :safe_by_default, :target_sql_mode, :lock_timeout_retries,
+      :lock_timeout_retry_delay, :alphabetize_schema, :skipped_databases,
+      :remove_invalid_indexes
     attr_writer :lock_timeout_limit
   end
   self.auto_analyze = false

--- a/lib/strong_migrations/adapters/abstract_adapter.rb
+++ b/lib/strong_migrations/adapters/abstract_adapter.rb
@@ -47,10 +47,6 @@ module StrongMigrations
       def max_constraint_name_length
       end
 
-      def supports_transaction_timeout?
-        false
-      end
-
       private
 
       def connection

--- a/lib/strong_migrations/adapters/abstract_adapter.rb
+++ b/lib/strong_migrations/adapters/abstract_adapter.rb
@@ -47,6 +47,10 @@ module StrongMigrations
       def max_constraint_name_length
       end
 
+      def supports_transaction_timeout?
+        false
+      end
+
       private
 
       def connection

--- a/lib/strong_migrations/adapters/abstract_adapter.rb
+++ b/lib/strong_migrations/adapters/abstract_adapter.rb
@@ -24,6 +24,10 @@ module StrongMigrations
         # do nothing
       end
 
+      def set_transaction_timeout(timeout)
+        # do nothing
+      end
+
       def add_column_default_safe?
         false
       end

--- a/lib/strong_migrations/adapters/postgresql_adapter.rb
+++ b/lib/strong_migrations/adapters/postgresql_adapter.rb
@@ -28,7 +28,7 @@ module StrongMigrations
       end
 
       def supports_transaction_timeout?
-        server_version > Gem::Version.new("17.0")
+        server_version >= Gem::Version.new("17.0")
       end
 
       def set_transaction_timeout(timeout)

--- a/lib/strong_migrations/adapters/postgresql_adapter.rb
+++ b/lib/strong_migrations/adapters/postgresql_adapter.rb
@@ -27,6 +27,10 @@ module StrongMigrations
         set_timeout("lock_timeout", timeout)
       end
 
+      def supports_transaction_timeout?
+        server_version > Gem::Version.new("17.0")
+      end
+
       def set_transaction_timeout(timeout)
         set_timeout("transaction_timeout", timeout)
       end

--- a/lib/strong_migrations/adapters/postgresql_adapter.rb
+++ b/lib/strong_migrations/adapters/postgresql_adapter.rb
@@ -27,6 +27,10 @@ module StrongMigrations
         set_timeout("lock_timeout", timeout)
       end
 
+      def set_transaction_timeout(timeout)
+        set_timeout("transaction_timeout", timeout)
+      end
+
       def check_lock_timeout(limit)
         lock_timeout = connection.select_all("SHOW lock_timeout").first["lock_timeout"]
         lock_timeout_sec = timeout_to_sec(lock_timeout)

--- a/lib/strong_migrations/adapters/postgresql_adapter.rb
+++ b/lib/strong_migrations/adapters/postgresql_adapter.rb
@@ -27,11 +27,9 @@ module StrongMigrations
         set_timeout("lock_timeout", timeout)
       end
 
-      def supports_transaction_timeout?
-        server_version >= Gem::Version.new("17.0")
-      end
-
       def set_transaction_timeout(timeout)
+        return unless server_version >= Gem::Version.new("17.0")
+
         set_timeout("transaction_timeout", timeout)
       end
 

--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -184,7 +184,7 @@ module StrongMigrations
       if StrongMigrations.lock_timeout
         adapter.set_lock_timeout(StrongMigrations.lock_timeout)
       end
-      if adapter.supports_transaction_timeout? && StrongMigrations.transaction_timeout
+      if StrongMigrations.transaction_timeout
         adapter.set_transaction_timeout(StrongMigrations.transaction_timeout)
       end
 

--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -184,6 +184,9 @@ module StrongMigrations
       if StrongMigrations.lock_timeout
         adapter.set_lock_timeout(StrongMigrations.lock_timeout)
       end
+      if StrongMigrations.transaction_timeout
+        adapter.set_transaction_timeout(StrongMigrations.transaction_timeout)
+      end
 
       @timeouts_set = true
     end

--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -184,7 +184,7 @@ module StrongMigrations
       if StrongMigrations.lock_timeout
         adapter.set_lock_timeout(StrongMigrations.lock_timeout)
       end
-      if StrongMigrations.transaction_timeout
+      if adapter.supports_transaction_timeout? && StrongMigrations.transaction_timeout
         adapter.set_transaction_timeout(StrongMigrations.transaction_timeout)
       end
 


### PR DESCRIPTION
PG17 supports [transaction_timeout](https://postgresqlco.nf/doc/en/param/transaction_timeout/). Our application has set a relatively short value for this, as we have for statement_timeout. 

StrongMigrations changes the statement timeout to a large value. This is useless if the transaction_timeout itself remains low:

> The limit applies both to explicit transactions (started with BEGIN) and to an implicitly started transaction corresponding to a single statement.

—> StrongMigrations needs to override it to a larger value for migrations to pass.

I have not added any tests so far. Please let me know if there is something specific you would like me to test.