### PR TITLE
Set transaction_timeout before opening the transaction

### DIFF
--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -151,6 +151,16 @@ module StrongMigrations
       StrongMigrations.skipped_databases.map(&:to_s).include?(db_config_name)
     end
 
+    def set_transaction_timeout
+      return if defined?(@transaction_timeout_set)
+
+      if StrongMigrations.transaction_timeout
+        adapter.set_transaction_timeout(StrongMigrations.transaction_timeout)
+      end
+
+      @transaction_timeout_set = true
+    end
+
     private
 
     def check_adapter
@@ -182,9 +192,6 @@ module StrongMigrations
 
       if StrongMigrations.statement_timeout
         adapter.set_statement_timeout(StrongMigrations.statement_timeout)
-      end
-      if StrongMigrations.transaction_timeout
-        adapter.set_transaction_timeout(StrongMigrations.transaction_timeout)
       end
       if StrongMigrations.lock_timeout
         adapter.set_lock_timeout(StrongMigrations.lock_timeout)

--- a/lib/strong_migrations/migrator.rb
+++ b/lib/strong_migrations/migrator.rb
@@ -6,6 +6,7 @@ module StrongMigrations
 
       # handle MigrationProxy class
       migration = migration.send(:migration) if !migration.is_a?(ActiveRecord::Migration) && migration.respond_to?(:migration, true)
+
       checker = migration.send(:strong_migrations_checker)
       return super if checker.skip?
 

--- a/lib/strong_migrations/migrator.rb
+++ b/lib/strong_migrations/migrator.rb
@@ -1,13 +1,16 @@
 module StrongMigrations
   module Migrator
     def ddl_transaction(migration, ...)
+      checker = migration.send(:strong_migrations_checker)
+      return super if checker.skip?
+
+      checker.set_transaction_timeout
+
       return super unless StrongMigrations.lock_timeout_retries > 0 && use_transaction?(migration)
 
       # handle MigrationProxy class
       migration = migration.send(:migration) if !migration.is_a?(ActiveRecord::Migration) && migration.respond_to?(:migration, true)
 
-      checker = migration.send(:strong_migrations_checker)
-      return super if checker.skip?
 
       # retry migration since the entire transaction needs to be rerun
       checker.retry_lock_timeouts(check_committed: true) do

--- a/lib/strong_migrations/migrator.rb
+++ b/lib/strong_migrations/migrator.rb
@@ -1,16 +1,16 @@
 module StrongMigrations
   module Migrator
     def ddl_transaction(migration, ...)
+      retries = StrongMigrations.lock_timeout_retries > 0 && use_transaction?(migration)
+      return super unless retries || StrongMigrations.transaction_timeout
+
+      # handle MigrationProxy class
+      migration = migration.send(:migration) if !migration.is_a?(ActiveRecord::Migration) && migration.respond_to?(:migration, true)
       checker = migration.send(:strong_migrations_checker)
       return super if checker.skip?
 
       checker.set_transaction_timeout
-
-      return super unless StrongMigrations.lock_timeout_retries > 0 && use_transaction?(migration)
-
-      # handle MigrationProxy class
-      migration = migration.send(:migration) if !migration.is_a?(ActiveRecord::Migration) && migration.respond_to?(:migration, true)
-
+      return super unless retries
 
       # retry migration since the entire transaction needs to be rerun
       checker.retry_lock_timeouts(check_committed: true) do

--- a/test/migrations/timeouts.rb
+++ b/test/migrations/timeouts.rb
@@ -27,6 +27,17 @@ class CheckTimeouts < TestMigration
   end
 end
 
+class CheckTransactionTimeoutWithoutStatement < TestMigration
+  include Helpers
+
+  def change
+    $transaction_timeout =
+      if postgresql? && transaction_timeout?
+        connection.select_all("SHOW transaction_timeout").first["transaction_timeout"]
+      end
+  end
+end
+
 class CheckLockTimeout < TestMigration
   def change
     safety_assured { execute "SELECT 1" }

--- a/test/timeouts_test.rb
+++ b/test/timeouts_test.rb
@@ -76,6 +76,16 @@ class TimeoutsTest < Minitest::Test
     assert_equal "1001ms", $transaction_timeout
   end
 
+  def test_transaction_timeout_is_set_before_statements
+    skip unless transaction_timeout?
+
+    StrongMigrations.transaction_timeout = 1.seconds
+
+    migrate CheckTransactionTimeoutWithoutStatement
+
+    assert_equal "1s", $transaction_timeout
+  end
+
   def test_lock_timeout_float
     skip unless postgresql?
 


### PR DESCRIPTION
Hello,

I was running into this issue with the transaction timeout in Postgres that it need to be set before opening the transaction to actually apply (upstream [bug report](https://www.postgresql.org/message-id/554670a7-7560-4d18-8ecb-8518fddf2b9d%40app.fastmail.com)). 

I suggest the way to go to be to set that timeout in the `ddl_transaction` before the transaction opens. The test I added indeed fails without the changes to `lib/`. 

Happy to get your feedback on the strategy