### PR TITLE
Add note about safety_assured not carrying over during rollback

### DIFF
--- a/lib/strong_migrations/error_messages.rb
+++ b/lib/strong_migrations/error_messages.rb
@@ -89,7 +89,10 @@ class %{migration_name} < ActiveRecord::Migration%{migration_suffix}
   def change
     safety_assured { %{command} }
   end
-end",
+end
+
+Note: safety_assured does not carry over when rolling back a change method.
+Use up and down methods instead if you need to roll back safely.",
 
     rename_column:
 "Renaming a column that's in use will cause errors


### PR DESCRIPTION
Fixes #284.

When using `safety_assured` with `add_column` inside a `change` method, the `safety_assured` context does not carry over when Rails reverts the migration. This can be confusing when `check_down` is enabled, as the rollback hits the `remove_column` check with no indication of why `safety_assured` didn't help.

Building on d15e3fa which improved the error output formatting for rollbacks, this adds a brief note to the message content itself suggesting the use of `up` and `down` methods instead.