### PR TITLE
Add metadata to gemspec

### DIFF
--- a/strong_migrations.gemspec
+++ b/strong_migrations.gemspec
@@ -15,5 +15,11 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.3"
 
+  spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/v#{spec.version}/CHANGELOG.md"
+  spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}"
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "#{spec.homepage}/tree/v#{spec.version}"
+
   spec.add_dependency "activerecord", ">= 7.2"
 end


### PR DESCRIPTION
Configures links that will appear on this gem's page on RubyGems.org when new versions of the gem are released. See the [specification reference](https://guides.rubygems.org/specification-reference/#metadata) for more.

If nothing else, I'd like to see the addition of `changelog_uri` merged as its presence is quite helpful when working through gem updates and navigating via RubyGems.org.

Note that the duplicative `homepage_uri` accounts for [this issue](https://github.com/rubygems/rubygems.org/issues/4924).

Thanks for considering this change!