### PR TITLE
Added safe_change_table to inspect operations inside change_table blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Added `safe_change_table` to inspect operations inside `change_table` blocks
+- Made plain `change_table` safe by default when `StrongMigrations.safe_by_default = true`
+
 ## 2.7.0 (2026-04-25)
 
 - Added check for `add_foreign_key` with MySQL and MariaDB

--- a/README.md
+++ b/README.md
@@ -423,6 +423,31 @@ class ExecuteSQL < ActiveRecord::Migration[8.1]
 end
 ```
 
+### Inspecting change_table blocks
+
+Strong Migrations rejects plain `change_table` because it cannot see what happens inside the block. Use `safe_change_table` instead. Each operation in the block is validated as if it were a top-level call:
+
+```ruby
+class AddNamesToUsers < ActiveRecord::Migration[8.1]
+  def change
+    safe_change_table :users, bulk: true do |t|
+      t.string :first_name
+      t.string :last_name
+      t.index [:first_name, :last_name]
+    end
+  end
+end
+```
+
+If any operation in the block would be unsafe, the migration is rejected with the same error message as the equivalent top-level call.
+
+Note: the block is executed twice
+
+- once to capture operations for inspection (no SQL is issued)
+- once by the real `change_table` to apply the changes.
+
+So any non-DDL side effects in the block run twice. This matches Active Record’s existing behavior for `change_table` with `bulk: true`.
+
 ### Backfilling data
 
 Note: Strong Migrations does not detect dangerous backfills.
@@ -850,6 +875,7 @@ Make certain operations safe by default. This allows you to write the code under
 - adding a foreign key
 - adding a check constraint
 - setting NOT NULL on an existing column
+- using `change_table` (each operation in the block is validated as if it were a top-level call)
 
 Add to `config/initializers/strong_migrations.rb`:
 

--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -120,6 +120,28 @@ module StrongMigrations
       result
     end
 
+    def check_change_table_block(table_name, &block)
+      check_adapter
+      check_version_supported
+
+      recorder = ActiveRecord::Migration::CommandRecorder.new(connection)
+      table = connection.update_table_definition(table_name, recorder)
+      block.call(table)
+
+      # operations inside change_table cannot use the safe_by_default
+      # rewrites (e.g. concurrent indexes), so disable them for the dry run
+      # to avoid issuing real SQL and to surface unsafe operations as errors
+      previous_safe_by_default = StrongMigrations.safe_by_default
+      begin
+        StrongMigrations.safe_by_default = false
+        recorder.commands.each do |method, args, _inner_block|
+          perform(method, *args) { nil }
+        end
+      ensure
+        StrongMigrations.safe_by_default = previous_safe_by_default
+      end
+    end
+
     def perform_method(method, *args)
       if StrongMigrations.remove_invalid_indexes && direction == :up && method == :add_index && postgresql?
         remove_invalid_index_if_needed(*args)

--- a/lib/strong_migrations/migration.rb
+++ b/lib/strong_migrations/migration.rb
@@ -6,8 +6,12 @@ module StrongMigrations
       connection.begin_db_transaction if strong_migrations_checker.transaction_disabled
     end
 
-    def method_missing(method, *args)
+    def method_missing(method, *args, &block)
       return super if is_a?(ActiveRecord::Schema) || is_a?(ActiveRecord::Schema::Definition)
+
+      if method == :change_table && block && strong_migrations_checker.safe_by_default_method?(:change_table)
+        return safe_change_table(*args, &block)
+      end
 
       catch(:safe) do
         strong_migrations_checker.perform(method, *args) do
@@ -24,6 +28,13 @@ module StrongMigrations
       else
         super
       end
+    end
+
+    def safe_change_table(table_name, **options, &block)
+      raise ArgumentError, "safe_change_table requires a block" unless block
+
+      strong_migrations_checker.check_change_table_block(table_name, &block)
+      safety_assured { connection.change_table(table_name, **options, &block) }
     end
 
     def safety_assured

--- a/lib/strong_migrations/safe_methods.rb
+++ b/lib/strong_migrations/safe_methods.rb
@@ -1,7 +1,7 @@
 module StrongMigrations
   module SafeMethods
     def safe_by_default_method?(method)
-      StrongMigrations.safe_by_default && !version_safe? && [:add_index, :add_belongs_to, :add_reference, :remove_index, :add_foreign_key, :add_check_constraint, :change_column_null].include?(method)
+      StrongMigrations.safe_by_default && !version_safe? && [:add_index, :add_belongs_to, :add_reference, :remove_index, :add_foreign_key, :add_check_constraint, :change_column_null, :change_table].include?(method)
     end
 
     def safe_add_index(*args, **options)

--- a/test/change_table_test.rb
+++ b/test/change_table_test.rb
@@ -1,0 +1,44 @@
+require_relative "test_helper"
+
+class ChangeTableTest < Minitest::Test
+  def test_change_table
+    assert_unsafe ChangeTable
+  end
+
+  def test_safe_change_table
+    assert_safe SafeChangeTable
+  end
+
+  def test_safe_change_table_unsafe
+    assert_unsafe SafeChangeTableUnsafe, "Active Record caches attributes"
+  end
+
+  def test_safe_change_table_does_not_apply_on_failure
+    columns_before = User.columns_hash.keys
+    assert_unsafe SafeChangeTableCustomCheck
+    User.reset_column_information
+    columns_after = User.columns_hash.keys
+    assert_equal columns_before.sort, columns_after.sort
+  ensure
+    User.reset_column_information
+  end
+
+  def test_safe_change_table_custom_check
+    assert_unsafe SafeChangeTableCustomCheck, "Cannot add forbidden column"
+  end
+
+  def test_safe_change_table_bulk
+    skip unless mysql? || mariadb?
+
+    statements = capture_statements do
+      migrate SafeChangeTableBulk, direction: :up
+    end
+    alters = statements.select { |s| s.start_with?("ALTER TABLE") }
+    assert_equal 1, alters.size
+    migrate SafeChangeTableBulk, direction: :down
+  end
+
+  def test_safe_change_table_no_block
+    assert_argument_error SafeChangeTableNoBlock
+  end
+end

--- a/test/migrations/change_table.rb
+++ b/test/migrations/change_table.rb
@@ -1,0 +1,79 @@
+class ChangeTable < TestMigration
+  def change
+    change_table :users do |t|
+      t.string :nice
+    end
+  end
+end
+
+class SafeChangeTable < TestMigration
+  def up
+    safe_change_table :users do |t|
+      t.string :first_name
+      t.string :last_name
+    end
+  end
+
+  def down
+    remove_column :users, :first_name
+    remove_column :users, :last_name
+  end
+end
+
+class SafeChangeTableUnsafe < TestMigration
+  def change
+    safe_change_table :users do |t|
+      t.remove :name
+    end
+  end
+end
+
+class SafeChangeTableCustomCheck < TestMigration
+  def change
+    safe_change_table :users do |t|
+      t.string :forbidden
+    end
+  end
+end
+
+class SafeChangeTableBulk < TestMigration
+  def up
+    safe_change_table :users, bulk: true do |t|
+      t.string :first_name
+      t.string :last_name
+    end
+  end
+
+  def down
+    remove_column :users, :first_name
+    remove_column :users, :last_name
+  end
+end
+
+class SafeChangeTableNoBlock < TestMigration
+  def change
+    safe_change_table :users
+  end
+end
+
+class ChangeTableSafeOps < TestMigration
+  def up
+    change_table :users do |t|
+      t.string :first_name
+      t.string :last_name
+    end
+  end
+
+  def down
+    remove_column :users, :first_name
+    remove_column :users, :last_name
+  end
+end
+
+class ChangeTableUnsafeOp < TestMigration
+  def change
+    change_table :users do |t|
+      t.remove :name
+    end
+  end
+end

--- a/test/safe_by_default_test.rb
+++ b/test/safe_by_default_test.rb
@@ -297,4 +297,12 @@ class SafeByDefaultTest < Minitest::Test
 
     assert_safe ChangeColumnNullLongName
   end
+
+  def test_change_table
+    assert_safe ChangeTableSafeOps
+  end
+
+  def test_change_table_unsafe
+    assert_unsafe ChangeTableUnsafeOp, "Active Record caches attributes"
+  end
 end


### PR DESCRIPTION
## Summary

Adds `safe_change_table`, a checked alternative to `safety_assured { change_table … }`. Each operation inside the block is validated through the same per-operation checks Strong Migrations applies at the top level. If any operation would be unsafe, the migration is rejected with the same error message as the equivalent top-level call.

```ruby
class AddNamesToUsers < ActiveRecord::Migration[8.1]
  def change
    safe_change_table :users, bulk: true do |t|
      t.string :first_name
      t.string :last_name
      t.index [:first_name, :last_name]
    end
  end
end
```

When `StrongMigrations.safe_by_default = true`, plain `change_table` is automatically rewritten to `safe_change_table`.

## Motivation

Today, `change_table` is rejected outright and the only workaround is `safety_assured { change_table … }`, which has two undesirable properties:

1. It disables every check (including custom checks registered via `StrongMigrations.add_check`), even for operations that would have been individually safe.
2. It penalizes the most efficient pattern for multi-column changes on MySQL/MariaDB. Users want `change_table :t, bulk: true` to combine multiple ALTERs into a single statement, but the only way to use it today is via `safety_assured`.

`safe_change_table` gives a checked equivalent. The bulk ALTER still runs as one statement, but every operation inside the block is validated first.

## How it works

1. The block is yielded to a `Table` proxy backed by `ActiveRecord::Migration::CommandRecorder`, capturing each operation as `(method, args, block)` without issuing any SQL.
2. Each recorded command is dispatched through the existing `Checker#perform` method, so it goes through the same per-operation checks (`check_add_column`, `check_add_index`, `check_change_column`, `check_remove_column`, `check_add_reference`, etc.) and any custom checks registered via `StrongMigrations.add_check`.
3. If all checks pass, `connection.change_table(table_name, **options, &block)` is called inside `safety_assured` so the real changes are applied (preserving `bulk: true` and any other options).

The block runs twice: once for inspection, once for execution. This is the same pattern Active Record already uses for `change_table … bulk: true`, so blocks that work with `bulk: true` today work with `safe_change_table` unchanged. Non-DDL side effects in the block run twice; this is documented in the README.

## Backwards compatibility

- Plain `change_table` (without the `safe_` prefix) is unchanged. It still raises, preserving the existing guardrail.
- `safety_assured { change_table … }` still works.
- Users who don't enable `safe_by_default` see no behavior change.

## Tests

New `test/change_table_test.rb` covers:

- Plain `change_table` still raises (regression).
- `safe_change_table` with safe operations applies the changes and is reversible.
- `safe_change_table` containing an unsafe operation raises and applies nothing.
- Custom checks (`StrongMigrations.add_check`) fire for operations inside the block.
- `safe_change_table :t, bulk: true` issues a single bundled `ALTER TABLE` on MySQL/MariaDB.
- `safe_change_table` without a block raises `ArgumentError`.

`test/safe_by_default_test.rb` is extended to cover the `change_table` rewrite (safe ops apply, unsafe ops still raise).

The full suite passes on PostgreSQL, MySQL, and Trilogy.

## Docs

- New section in `README.md`.
- `change_table` listed under "Safe by Default".
- `CHANGELOG.md` entry under a new `Unreleased` section.